### PR TITLE
fix(merge): extend overlay guard from empty-only to shrink-protection

### DIFF
--- a/scripts/merge_checkpoints.py
+++ b/scripts/merge_checkpoints.py
@@ -146,22 +146,32 @@ def _apply_overlay(
                     f'SELECT COUNT(*) FROM overlay."{name}"'
                 ).fetchone()[0]
 
-                # Refuse to wipe base rows with an empty overlay. Observed
-                # regression: fetch job's step failed (continue-on-error),
-                # the fetcher wrote 0 rows for its table, overlay DB had 0
-                # rows for that table, DELETE-then-INSERT left base at 0
-                # and that 0-row state got snapshotted into the next
-                # checkpoint, permanently losing accumulated rows (e.g.
-                # cloud_fraction 523K -> 0 on 2026-04-18 before this guard
-                # was added). If overlay is empty, keep base as-is.
-                if overlay_count == 0 and before > 0:
+                # Refuse to wipe base rows when overlay has fewer rows than
+                # base. All fetchers are append-only: each run restores the
+                # prior checkpoint, then INSERT-OR-IGNOREs new rows. So a
+                # successful run yields overlay_count >= before. Shrink
+                # means restore failed (fetcher started from empty DB and
+                # only wrote new fetches) or init_db reset the table.
+                # Observed regressions:
+                #   - cloud_fraction 523K -> 0 on 2026-04-18 (overlay empty)
+                #   - modis_lst 488 -> 338 -> ... shrink chain on 2026-04-25
+                # Keep base in either case; rely on the next successful run
+                # to grow past base.
+                if overlay_count < before:
+                    deficit = before - overlay_count
+                    if overlay_count == 0:
+                        why = "overlay empty"
+                    else:
+                        why = f"overlay shrunk by {deficit:,} rows"
                     print(
-                        f"  {name}: overlay empty (0 rows) but base has "
-                        f"{before:,} rows -- KEEPING base "
-                        f"(guard against wipe-and-reset from failed fetch)"
+                        f"  {name}: overlay has {overlay_count:,} rows but "
+                        f"base has {before:,} rows ({why}) -- KEEPING base "
+                        f"(append-only fetchers should never produce a "
+                        f"smaller overlay; likely cause: checkpoint restore "
+                        f"failure or fetcher init_db reset)"
                     )
                     skipped.append(
-                        (name, f"overlay empty; base preserved ({before:,} rows)")
+                        (name, f"{why}; base preserved ({before:,} rows)")
                     )
                     continue
 

--- a/scripts/smoke_test_merge_checkpoints.py
+++ b/scripts/smoke_test_merge_checkpoints.py
@@ -325,16 +325,22 @@ def test_empty_overlay_preserves_base(tmp: str) -> None:
     print("PASS: empty overlay preserves base accumulated rows (regression guard)")
 
 
-def test_nonempty_overlay_still_replaces(tmp: str) -> None:
-    """Verify the empty-overlay guard doesn't block normal overlay
-    application when overlay has >=1 row.
+def test_grown_overlay_replaces_base(tmp: str) -> None:
+    """Verify the shrink-protection guard does not block legitimate growth.
+
+    Append-only fetchers grow the overlay by restoring base rows and
+    INSERT-OR-IGNOREing new fetches. overlay_count >= before is the
+    normal happy path and must apply.
     """
     base = os.path.join(tmp, "base.db")
     overlay = os.path.join(tmp, "ov.db")
     dst = os.path.join(tmp, "dst.db")
 
-    make_db(base, {"cloud_fraction": [(1, "old"), (2, "old2")]})
-    make_db(overlay, {"cloud_fraction": [(1, "new")]})
+    make_db(base, {"cloud_fraction": [(1, "row-1"), (2, "row-2")]})
+    make_db(
+        overlay,
+        {"cloud_fraction": [(1, "row-1"), (2, "row-2"), (3, "row-3-new")]},
+    )
 
     rc, out, _ = run_merge(
         [
@@ -345,15 +351,66 @@ def test_nonempty_overlay_still_replaces(tmp: str) -> None:
         ]
     )
     assert rc == 0, out
-    # 1 fresh row replaces base's 2 rows (even though fewer, overlay is the
-    # authority when it has >=1 row).
-    assert fetch_vals(dst, "cloud_fraction") == ["new"], (
-        f"overlay with 1 row should replace base; got {fetch_vals(dst, 'cloud_fraction')}"
-    )
+    assert fetch_vals(dst, "cloud_fraction") == [
+        "row-1",
+        "row-2",
+        "row-3-new",
+    ], "grown overlay should apply"
     assert "KEEPING base" not in out, (
-        "guard should NOT trigger when overlay has rows"
+        "guard should NOT trigger when overlay grows"
     )
-    print("PASS: non-empty overlay replaces base normally")
+    print("PASS: grown overlay applies normally")
+
+
+def test_shrunk_overlay_preserves_base(tmp: str) -> None:
+    """Regression guard: if overlay has fewer rows than base, the merge
+    must KEEP base. Caused modis_lst 488 -> 338 -> ... shrink chain on
+    2026-04-25 when fetch_modis_lst.py started from a failed checkpoint
+    restore (effectively empty DB) and wrote only newly fetched rows
+    into the overlay. Append-only fetchers must produce
+    overlay_count >= base_count; a shrink signals restore/init failure.
+    """
+    base = os.path.join(tmp, "base.db")
+    overlay = os.path.join(tmp, "ov.db")
+    dst = os.path.join(tmp, "dst.db")
+
+    make_db(
+        base,
+        {
+            "modis_lst": [(i, f"row-{i}") for i in range(1, 11)],
+            "earthquakes": [(1, "a")],
+        },
+    )
+    make_db(
+        overlay,
+        {
+            "modis_lst": [
+                (100, "fresh-1"),
+                (101, "fresh-2"),
+                (102, "fresh-3"),
+            ]
+        },
+    )
+
+    rc, out, _ = run_merge(
+        [
+            "--base", base,
+            "--overlay", f"{overlay}:modis_lst",
+            "--dst", dst,
+            "--require-base",
+        ]
+    )
+    assert rc == 0, out
+    assert count_rows(dst, "modis_lst") == 10, (
+        "base rows wiped by shrunk overlay"
+    )
+    assert "KEEPING base" in out, (
+        "expected shrink-protection log message"
+    )
+    assert "shrunk" in out, (
+        "expected shrunk wording in skip reason"
+    )
+    print("PASS: shrunk overlay preserves base accumulated rows (regression guard)")
 
 
 def test_all_overlays_missing(tmp: str) -> None:
@@ -394,7 +451,8 @@ def main() -> int:
             test_overlay_creates_table_new_in_base,
             test_injection_name_rejected,
             test_empty_overlay_preserves_base,
-            test_nonempty_overlay_still_replaces,
+            test_grown_overlay_replaces_base,
+            test_shrunk_overlay_preserves_base,
             test_all_overlays_missing,
         ]
         for t in tests:
@@ -411,7 +469,7 @@ def main() -> int:
             finally:
                 shutil.rmtree(sub, ignore_errors=True)
     print()
-    print("ALL 10 SMOKE TESTS PASSED")
+    print("ALL 11 SMOKE TESTS PASSED")
     return 0
 
 


### PR DESCRIPTION
## Summary

Extend `_apply_overlay` guard in `scripts/merge_checkpoints.py` from blocking only `overlay_count == 0` to blocking any `overlay_count < before`. Append-only fetchers should never produce a smaller overlay than the restored base; a shrink signals checkpoint restore failure or `init_db` reset.

## Why

Observed: `modis_lst` shrink chain (2026-04-25) — `488 -> 338` rows where overlay was non-empty (so existing empty-overlay guard didn't trigger) but smaller than base. The DELETE-then-INSERT path overwrote base accumulated rows.

Verified by Opus subagent investigation: fetchers (e.g. `fetch_modis_lst.py`) are append-only via `INSERT OR IGNORE` and depend on checkpoint restore for base preservation. When restore fails, fetcher writes only newly fetched rows, producing a shrunk overlay that wipes base.

## Change

```python
# Before
if overlay_count == 0 and before > 0:
    skipped.append(...); continue

# After
if overlay_count < before:
    deficit = before - overlay_count
    why = "overlay empty" if overlay_count == 0 else f"overlay shrunk by {deficit:,} rows"
    skipped.append((name, f"{why}; base preserved ({before:,} rows)"))
    continue
```

The new guard subsumes the old empty case and adds shrink coverage.

## Test plan

- [x] `scripts/smoke_test_merge_checkpoints.py`: 11/11 PASS locally
  - Rewrote `test_nonempty_overlay_still_replaces` to `test_grown_overlay_replaces_base` (old form was incidentally testing shrink-allowed behavior, now rejected)
  - Added `test_shrunk_overlay_preserves_base` regression guard with explicit modis_lst 488->338 scenario
- [x] Empty-overlay regression case still preserved (`test_empty_overlay_preserves_base`)
- [ ] Next backfill cron run: confirm `modis_lst` row count no longer shrinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safeguard to prevent base data deletion in more scenarios where overlay data is incomplete.
  * Enhanced diagnostic messages with detailed row counts and specific causes for data retention decisions.

* **Tests**
  * Expanded test coverage for checkpoint merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->