### PR TITLE
refactor(snet): align snet_waveform with fnet round-1 quality fixes

### DIFF
--- a/scripts/fetch_snet_waveform.py
+++ b/scripts/fetch_snet_waveform.py
@@ -847,7 +847,7 @@ def _save_records_sync(conn, records: list[dict], now_str: str) -> tuple[int, in
     inserted = skipped = 0
     for rec in records:
         try:
-            conn.execute(
+            cursor = conn.execute(
                 """INSERT OR IGNORE INTO snet_waveform
                    (station_id, date_str, segment_hour, sensor_type,
                     rms_z, rms_h, hv_ratio, lf_power, hf_power,
@@ -865,7 +865,10 @@ def _save_records_sync(conn, records: list[dict], now_str: str) -> tuple[int, in
                     rec["cable_segment"], now_str,
                 ),
             )
-            inserted += 1
+            if cursor.rowcount == 1:
+                inserted += 1
+            else:
+                skipped += 1
         except Exception as exc:
             logger.warning("Insert failed for %s/%s/%s: %s",
                            rec["station_id"], rec["date_str"],
@@ -1044,11 +1047,9 @@ async def main() -> None:
     current = (now_utc - timedelta(days=RECENT_DAYS + 1)).replace(
         hour=0, minute=0, second=0, microsecond=0, tzinfo=None
     )
-    while current >= snet_start and len(backfill_dates) < MAX_BACKFILL_DAYS_PER_RUN * 3:
+    while current >= snet_start and len(backfill_dates) < MAX_BACKFILL_DAYS_PER_RUN:
         backfill_dates.append(current)
         current -= timedelta(days=1)
-    # Most recent gaps first
-    backfill_dates = backfill_dates[:MAX_BACKFILL_DAYS_PER_RUN]
 
     # Build interleaved fetch list: (date, n_segments, code, config)
     dates_to_fetch = []
@@ -1126,7 +1127,7 @@ async def main() -> None:
     # All HinetPy + DB work runs synchronously in an executor thread.
     # Each item's records are committed immediately so data survives timeout kills.
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     result = await loop.run_in_executor(
         None, _fetch_and_save, user, password, dates_to_fetch,
     )


### PR DESCRIPTION
## Summary

Backports the round-1 CodeRabbit nitpicks from PR #97 (F-net) into the older S-net fetcher. The same three latent issues existed on the snet side and were tracked in memory as a follow-up.

| # | Location | Before | After |
|---|---|---|---|
| 1 | `_save_records_sync` | `inserted += 1` after every `execute` | `cursor.rowcount`-driven; duplicates now count as `skipped` |
| 2 | `async def main()` | `asyncio.get_event_loop()` | `asyncio.get_running_loop()` |
| 3 | `backfill_dates` loop | `< MAX_BACKFILL_DAYS_PER_RUN * 3` then `[:MAX_BACKFILL_DAYS_PER_RUN]` | direct `< MAX_BACKFILL_DAYS_PER_RUN` |

## Why now

PR #97 applied these fixes only to ``fetch_fnet_waveform.py`` and intentionally left ``fetch_snet_waveform.py`` asymmetric. Catching up keeps the two parallel fetchers consistent and fixes a real metric bug (item 1) where the inserted/skipped split silently overcounted inserts on duplicate rows.

## Test plan
- [x] AST parse + 3 patch markers verified (RPi5 smoke)
- [x] sqlite ``cursor.rowcount`` semantics confirmed against ``:memory:`` (1 / 0 for new / duplicate)
- [ ] CodeRabbit review
- [ ] Verify next scheduled ``fetch-snet`` job log shows accurate ``inserted=N skipped=M`` ratio after merge

## Notes

- No behaviour change on the happy path; metrics and code style catch up with the F-net counterpart.
- Field-by-field unchanged INSERT statement, so existing checkpoint DBs are fully compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected duplicate record handling to accurately count inserted versus skipped records.

* **Chores**
  * Optimized backfill scheduling to process a tighter set of dates per run, improving efficiency.
  * Updated internal async handling for better compliance with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->