### PR TITLE
fix(fnet): correct FNET_START_STR to operational era (2000-01-01)

### DIFF
--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -56,7 +56,9 @@ logger = logging.getLogger(__name__)
 
 FNET_NETWORK_CODE = "0103"
 FNET_SENSOR_TYPE = "broadband"
-FNET_START_STR = "1995-08-01"
+# Backfill window starts at the practical operational era (2000-01-01)
+# rather than the 1995 network inception, to keep gap_days realistic.
+FNET_START_STR = "2000-01-01"
 
 # HinetPy constraints — shared NIED account quota with S-net.
 # Split: snet 60 + fnet 60 = 120 per run (out of NIED ~150 daily budget).


### PR DESCRIPTION
## Summary

Carries out **N1** from the post-PR-#97 minor follow-ups recorded in memory. Moves ``FNET_START_STR`` from ``1995-08-01`` (F-net network inception) to ``2000-01-01`` (practical operational era).

## Why

The ``gap_days`` metric in coverage reports is computed as ``days(today) - days(FNET_START_STR)``, so the constant directly shapes the perceived backfill scope. With the 1995 anchor the metric counts 1995-1999 as "missing" data even though pre-2000 station coverage is sparse and no data is realistically obtainable there. The 2000-01-01 anchor matches conventional F-net research windows and produces a realistic backfill target.

## Changes

- ``scripts/fetch_fnet_waveform.py:59`` — ``FNET_START_STR = "2000-01-01"``
- 2-line comment added above the constant explaining the offset from the module docstring's "August 1995" reference (the docstring still correctly states the network's inception date).

## Test plan
- [x] AST parse OK
- [x] ``datetime.strptime("2000-01-01", "%Y-%m-%d")`` valid
- [x] ``gap_days`` now 26.3 years (vs. 30.7 years previously)
- [ ] CodeRabbit review
- [ ] Verify next coverage report shows realistic ``gap_days`` for ``fnet_waveform``

## Out of scope

The companion idea **N3** (Python-side ``asyncio.wait_for`` for graceful partial-save) was reviewed and deferred to a separate PR. A simple ``wait_for`` wrapper does not actually cancel the synchronous HinetPy call running in the executor thread, so a real graceful timeout requires per-call instrumentation inside ``_fetch_and_save`` (~50-100 lines). Tracked as Phase D3 in internal memory.