### PR TITLE
fix(fnet): correct SAC channel filter for HinetPy single-char components

### DIFF
--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -670,17 +670,14 @@ def _fetch_day(
                 station_id = parts[1]
                 channel = parts[3] if len(parts) > 3 else parts[-1]
 
-                # F-net distributes both BH (broadband 100Hz) and LH (long-period
-                # 1Hz) for some stations. Filter to BH only — mixing fs in the
-                # PSD path would corrupt feature values (Opus review C1).
-                if not channel or not channel.upper().startswith("BH"):
+                # HinetPy extract_sac outputs N.STATION.{U,N,E}.SAC — single-char
+                # component, instrument-specific codes (UB/NB/UA/NA/...) already
+                # normalized. fs consistency check below rejects mixed-rate.
+                ch_up = channel.upper() if channel else ""
+                comp = {"U": "Z", "N": "X", "E": "Y"}.get(ch_up)
+                if comp is None:
                     continue
-
-                suffix = channel[-1].upper()
-                if suffix in ("Z", "X", "Y", "N", "E"):
-                    # Map N→X (north) and E→Y (east) for F-net naming variant
-                    comp = {"N": "X", "E": "Y"}.get(suffix, suffix)
-                    station_files.setdefault(station_id, {})[comp] = str(sac_path)
+                station_files.setdefault(station_id, {})[comp] = str(sac_path)
 
             for station_id, comps in station_files.items():
                 if len(comps) < 3:

--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -690,8 +690,9 @@ def _fetch_day(
                 if data_z is None or data_x is None or data_y is None:
                     continue
 
-                # fs consistency check: BH* should all be 100 Hz, but a misclassified
-                # SAC of a different sample rate would silently corrupt the PSD.
+                # fs consistency check: HinetPy normalizes per (station, component) to
+                # one SAC, but a mixed-rate triplet (broadband 100Hz vs long-period 1Hz)
+                # would silently corrupt PSD — reject if any pair disagrees.
                 fs_z = info_z.get("fs", EXPECTED_FS) if info_z else EXPECTED_FS
                 fs_x = info_x.get("fs", EXPECTED_FS) if info_x else EXPECTED_FS
                 fs_y = info_y.get("fs", EXPECTED_FS) if info_y else EXPECTED_FS


### PR DESCRIPTION
## 概要

PR #97 で導入した F-net waveform fetcher (Step 5c) の channel filter が HinetPy の SAC filename format と非互換だったため、本番 cron run で F-net step は exit 0 で完走するが `fnet_waveform` table に **0 行も保存されない** バグを修正します。

## 原因

`scripts/fetch_fnet_waveform.py` L673 が `channel.upper().startswith("BH")` で channel code を filter していました。これは SEED 命名規則 (`BHU`/`BHN`/`BHE`) を前提にしていますが、HinetPy `extract_sac` は `N.STATION.{U,N,E}.SAC` という単一文字 component を出力します。

結果:
- すべての SAC が `startswith("BH")` で reject
- 全 chunk で `0 stations processed`
- `fnet_waveform` table は最終的に 0 行のまま

## 確認した証拠 (2026-04-27)

1. **GHA cron run 24964462897 logs**: F-net step は success だが `[WARNING] No waveform records retrieved` で終了。各 chunk で `42 SAC data successfully extracted` の後に `0 stations processed` を全 chunk で記録。
2. **BQ verification**: `data-platform-490901.geohazard` データセットには `snet_waveform` (598,875 rows / 1,292 dates) は存在するが `fnet_waveform` table 自体が作成されていない (= 0 rows なので BQ sync が table を作らない)。
3. **HinetPy 公式ドキュメント**: SAC filename format は `N.STATION.COMPONENT.SAC` (例 `N.NABC.U.SAC`)、components は U/N/E の単一文字。

## 修正内容

`fetch_fnet_waveform.py` L671-683 (-10/+7 行):
- `startswith("BH")` filter を削除 (HinetPy 出力と非互換)
- `U -> Z, N -> X, E -> Y` の mapping dict に置き換え
- comment を HinetPy の実際の出力仕様に合わせて更新
- fs 一貫性チェック (L703-708) は既存のまま - broadband/long-period が混在しても fs_z != fs_x で reject される

## 影響範囲

- `scripts/fetch_fnet_waveform.py` の 1 関数 (`_fetch_day`) のみ
- workflow / DB schema / S-net 側には変更なし

## 期待される効果

次の cron run (約 3h ごと) で:
- F-net step が station-level records を生成
- `fnet_waveform` table に行が insert される
- BQ light job 経由で `data-platform-490901.geohazard.fnet_waveform` table が作成される
- coverage Discord notify に F-net cov% が含まれる

## smoke test (RPi5)

- AST parse OK
- 旧 `startswith("BH")` 削除確認
- 新 dict `{"U": "Z", "N": "X", "E": "Y"}` 存在確認 (L677)

## Note

CodeRabbit + 自リポなので review pass 後即 merge 予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved SAC file component selection logic in waveform data processing. Updated filename interpretation to use deterministic component mapping, simplifying data filtering while maintaining existing consistency validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->