### PR TITLE
debug(fnet): log SAC filename samples and station_files summary

### DIFF
--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -661,6 +661,9 @@ def _fetch_day(
                 logger.warning("No SAC files decoded for %s %02d:00", date_str, hour)
                 continue
 
+            sample_names = [Path(p).name for p in sac_files[:2]]
+            logger.info("  extract_sac -> %d SAC files, sample: %s", len(sac_files), sample_names)
+
             station_files: dict = {}
             for sac_path in sac_files:
                 basename = Path(sac_path).stem
@@ -678,6 +681,13 @@ def _fetch_day(
                 if comp is None:
                     continue
                 station_files.setdefault(station_id, {})[comp] = str(sac_path)
+
+            if station_files:
+                first_st = next(iter(station_files))
+                logger.info("  station_files: %d stations, first=%s comps=%s",
+                            len(station_files), first_st, sorted(station_files[first_st].keys()))
+            else:
+                logger.info("  station_files: 0 stations (channel filter rejected all SACs)")
 
             for station_id, comps in station_files.items():
                 if len(comps) < 3:


### PR DESCRIPTION
## 概要

Phase C 検証で PR #100 (8ff0c4e) merge 後の cron run (HEAD `7977e0b`、run 25036945142) を確認したところ、F-net step は 18 分回って正常終了 (`Set output 'fetch_fnet_waveform'`) するものの、全 timepoint で **0 stations processed** が出ており、BQ `geohazard.fnet_waveform` テーブルが**未作成** (snet_waveform は存在) でした。

`90 channels found` → `90 channels to be extracted` → `0 stations processed` の経路の途中で全 SAC が reject されているが、現状 SAC filename も station_files の状態もログに出ていないため真因特定不能です。

## 変更

`scripts/fetch_fnet_waveform.py` に logger.info を 2 ブロック追加 (副作用ゼロ):

1. `extract_sac` 直後: SAC ファイル数 + 最初 2 個の filename
2. channel filter ループ後: `station_files` の station 数 + 最初の station の comp keys (`{Z, X, Y}` 想定)、空の場合は明示

これで次の cron run で:
- `0 SAC files` なら extract_sac 失敗
- SAC files あるが `0 stations` なら filter で全 reject (= component name 想定違い)
- stations あるが comps < 3 なら component triplet 不整合

## ロジック影響

なし。logger.info の追加のみ。既存処理は一切触らず。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging visibility in data fetching operations to provide detailed insights into processed files and filtering results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->