### PR TITLE
fix(fnet): use 2-char component map (UB/NB/EB) for HinetPy SAC filenames

### DIFF
--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -673,11 +673,12 @@ def _fetch_day(
                 station_id = parts[1]
                 channel = parts[3] if len(parts) > 3 else parts[-1]
 
-                # HinetPy extract_sac outputs N.STATION.{U,N,E}.SAC — single-char
-                # component, instrument-specific codes (UB/NB/UA/NA/...) already
-                # normalized. fs consistency check below rejects mixed-rate.
+                # F-net SAC component is 2-char (verified via PR #104 debug log,
+                # 2026-04-28): second char 'B' = broadband 100Hz (target), 'A' =
+                # long-period 1Hz (reject to avoid fs mismatch in PSD path).
+                # Sample filenames observed: N.ISIF.NB.SAC, N.ADMF.EB.SAC.
                 ch_up = channel.upper() if channel else ""
-                comp = {"U": "Z", "N": "X", "E": "Y"}.get(ch_up)
+                comp = {"UB": "Z", "NB": "X", "EB": "Y"}.get(ch_up)
                 if comp is None:
                     continue
                 station_files.setdefault(station_id, {})[comp] = str(sac_path)


### PR DESCRIPTION
## 概要

PR #104 の debug log により、HinetPy `extract_sac` が F-net (network 0103) で出力する SAC filename は **2-char component** (`UB`/`NB`/`EB` for broadband 100Hz、`UA`/`NA`/`EA` for long-period 1Hz) であることが run 25048720034 で実測確認されました。

```
extract_sac -> 42 SAC files, sample: ['N.ISIF.NB.SAC', 'N.ADMF.EB.SAC']
station_files: 0 stations (channel filter rejected all SACs)
```

PR #100 で `BH*` filter を `{U, N, E}` single-char に変更したのは過剰修正で、結果として全 SAC を reject していました。

## 修正

`scripts/fetch_fnet_waveform.py` の channel filter map を `{"U": "Z", "N": "X", "E": "Y"}` から **`{"UB": "Z", "NB": "X", "EB": "Y"}`** に変更:

- `UB`/`NB`/`EB` (broadband 100Hz) のみ採用
- `UA`/`NA`/`EA` (long-period 1Hz) は reject (fs mismatch 防止)
- comment にも実測 sample filename と PR #104 検証根拠を記録

## 期待される結果

42 SAC files / 1 chunk → 7 stations × 3 broadband (UB/NB/EB) = **7 stations processed** (現状 0)。BQ `geohazard.fnet_waveform` table も自動作成され row 蓄積開始。

## debug log は残置

PR #104 で追加した logger.info 2 ブロックは今後の検証 (HinetPy アップデート等) でも有用なため本 PR では削除しません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed waveform component code parsing to correctly identify broadband seismic data sources and ensure consistent extraction and validation of triplet data throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->