### PR TITLE
Free disk space at light job start to prevent _diag log fill

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1200,6 +1200,19 @@ jobs:
       restore_restored: ${{ steps.restore.outputs.restored }}
 
     steps:
+      # Free ~30GB of pre-installed software we never use, to keep the runner's
+      # _diag/Worker_*.log from filling the 14GB default disk during the ~2h
+      # serial fetcher run. Three consecutive runs (16:54/19:42/21:50 UTC on
+      # 2026-04-28) failed at the Snapshot DB step with
+      # "No space left on device : _diag/Worker_*.log" or
+      # "hosted runner lost communication". Removing dotnet/android/ghc/codeql
+      # is a well-known GHA disk-pressure mitigation; this workflow uses none
+      # of them.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

直近 3 run (16:54 / 19:42 / 21:50 UTC, all on HEAD `d64f7f6` 2026-04-28) で `light` job が同じ root cause で連続失敗:

```
System.IO.IOException: No space left on device :
'/home/runner/actions-runner/cached/2.334.0/_diag/Worker_*.log'
```

GitHub-hosted runner (`ubuntu-latest`) のデフォルト 14GB free disk が ~2h の serial fetcher 実行中に runner 内部の `_diag/Worker_*.log` で食い潰される。light.db (~1.15GB) の `Snapshot DB` step (PRAGMA integrity_check + sqlite backup, 一時的に disk 倍増) で完全に枯渇 → 一回 "hosted runner lost communication" / 二回 "No space left on device" で job 死亡。

その結果 `light.db` artifact が出ず、merge job の `--require-base` defensive guard が発動して BQ upload skip → `geohazard.fnet_waveform` table が ever 作成されない。Phase D4/PR #105 で F-net SAC channel filter は正しく動作しているのに (`station_files: 14 stations, comps=['X','Y','Z']` を log で確認済み)、BQ 反映が完全ブロックされていた。

## Fix

`light` job の最初に `Free disk space` step を追加。`/usr/share/dotnet`, `/usr/local/lib/android`, `/opt/ghc`, `/opt/hostedtoolcache/CodeQL` を削除して ~30GB 確保。既知の GHA disk-pressure 緩和パターンで、本 workflow はこれらの言語 / ツールを一切使用しない。`df -h` で直後の空き容量も log 出力 (将来同種問題切り分け用)。

third-party action は使わず inline `sudo rm -rf` で実装 (supply chain risk 回避)。

## Test plan

- [ ] CodeRabbit review pass
- [ ] PR merge 後の最初の cron run で light job が `Free disk space` step 実行を確認
- [ ] light job conclusion = success / artifact `backfill-light-*` upload 成功
- [ ] merge job conclusion = success / BQ `geohazard.fnet_waveform` table 作成 + row count > 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability by implementing automated cleanup of unused system components to prevent disk space issues during build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->