### PR TITLE
Per-table BQ row threshold override (fnet_waveform=100)

### DIFF
--- a/scripts/load_raw_to_bq.py
+++ b/scripts/load_raw_to_bq.py
@@ -407,6 +407,22 @@ TABLES = {
 # when the DB is empty or corrupted.
 MIN_ROWS_TO_UPLOAD = 1000
 
+# Per-table override for the minimum-row threshold.
+# Some tables are sparse by design (event-targeted backfill, rare phenomena)
+# and would never reach the global 1000-row floor in their bootstrap phase.
+# These tables still need the threshold > 0 so a corrupt-empty SQLite cannot
+# WRITE_TRUNCATE the BQ data to zero — just at a lower level appropriate for
+# the data's natural density.
+TABLE_MIN_ROWS_OVERRIDE = {
+    # F-net broadband waveform: targeted around M6+ earthquakes, ~14 active
+    # stations × ~3 components × a handful of recent dates → low hundreds
+    # of rows is realistic for the bootstrap phase. Phase D4 / PR #105 (SAC
+    # filter fix) + PR #106 (light-job disk fix) confirmed end-to-end pipeline,
+    # but cron #25086162850 produced 429 rows < 1000 and was therefore skipped,
+    # leaving fnet_waveform absent in BQ despite all upstream steps succeeding.
+    "fnet_waveform": 100,
+}
+
 
 def _sanitize(v):
     # json.dumps emits bare NaN/Infinity tokens which BQ rejects.
@@ -452,9 +468,12 @@ def main():
                 count = conn.execute(
                     "SELECT COUNT(*) FROM " + table_name  # table names are hardcoded above
                 ).fetchone()[0]
-                if count < MIN_ROWS_TO_UPLOAD:
+                threshold = TABLE_MIN_ROWS_OVERRIDE.get(
+                    table_name, MIN_ROWS_TO_UPLOAD
+                )
+                if count < threshold:
                     logger.info("%s: %d rows (< %d minimum) — skipping to protect BQ data",
-                                table_name, count, MIN_ROWS_TO_UPLOAD)
+                                table_name, count, threshold)
                     continue
 
                 logger.info("%s: streaming %d rows to gzip NDJSON...", table_name, count)

--- a/scripts/load_raw_to_bq.py
+++ b/scripts/load_raw_to_bq.py
@@ -415,7 +415,7 @@ MIN_ROWS_TO_UPLOAD = 1000
 # the data's natural density.
 TABLE_MIN_ROWS_OVERRIDE = {
     # F-net broadband waveform: targeted around M6+ earthquakes, ~14 active
-    # stations × ~3 components × a handful of recent dates → low hundreds
+    # stations x ~3 components x a handful of recent dates -> low hundreds
     # of rows is realistic for the bootstrap phase. Phase D4 / PR #105 (SAC
     # filter fix) + PR #106 (light-job disk fix) confirmed end-to-end pipeline,
     # but cron #25086162850 produced 429 rows < 1000 and was therefore skipped,


### PR DESCRIPTION
## Summary

`scripts/load_raw_to_bq.py` の `MIN_ROWS_TO_UPLOAD = 1000` 一律閾値が、event-targeted で sparse な `fnet_waveform` (M6+ 周辺、~14 stations × ~3 components × 数日 ≈ 数百行) を BQ に上げない原因になっていた。

直近の dispatch run #25086162850 (HEAD `6d685e3d`) で:
- Phase D4 / PR #105: F-net SAC channel filter fix (`{UB:Z, NB:X, EB:Y}`) 動作確認
- PR #106: light job `Free disk space` step で `_diag` log 圧迫解消、merge job 完走
- `merge_checkpoints.py`: `fnet_waveform: 0 -> 429 rows (overlay applied from /tmp/snet/geohazard.db)` / `Coverage report: fnet_waveform: 429 rows (2026-04-17 -> 2026-04-28)`
- `Upload to BigQuery`: `fnet_waveform: 429 rows (< 1000 minimum) — skipping to protect BQ data`

end-to-end pipeline は正常で、最後の安全ガードだけが bootstrap データを止めていた。

## Fix

`MIN_ROWS_TO_UPLOAD = 1000` を default として残しつつ、`TABLE_MIN_ROWS_OVERRIDE` dict を追加して per-table 上書きできるように:

```
TABLE_MIN_ROWS_OVERRIDE = {
    "fnet_waveform": 100,
}

threshold = TABLE_MIN_ROWS_OVERRIDE.get(table_name, MIN_ROWS_TO_UPLOAD)
if count < threshold:
    logger.info("%s: %d rows (< %d minimum) -- skipping ...", table_name, count, threshold)
    continue
```

- `fnet_waveform` のみ閾値を 100 に下げる (bootstrap 用、`429` は通る)
- 他 30 テーブルは `MIN_ROWS_TO_UPLOAD = 1000` のまま (corrupt/empty SQLite からの WRITE_TRUNCATE 防御維持)
- log message も override 値を表示するよう修正

## Test plan

- [ ] CodeRabbit review pass
- [ ] PR merge 後の最初の cron run で `Upload to BigQuery` log に streaming/upload 記録が出ることを確認
- [ ] BQ `data-platform-490901.geohazard.fnet_waveform` table 作成 + row count > 0 を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved data upload configuration with per-table row threshold settings for more flexible data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->