### PR TITLE
feat(waveform): Phase D3 graceful partial-save before SIGTERM

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1090,8 +1090,8 @@ jobs:
           HINET_PASS: ${{ secrets.HINET_PASS }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           SNET_MAX_REQUESTS: "60"
-          # Phase D3: graceful exit ~5min before SIGTERM (timeout-minutes: 75 = 4500s).
-          SNET_STEP_BUDGET_SEC: "4200"
+          # Phase D3: full step budget; script subtracts DEADLINE_MARGIN_SEC=300 (~5min) before SIGTERM at 4500s.
+          SNET_STEP_BUDGET_SEC: "4500"
         run: |
           pip install HinetPy 2>/dev/null || true
           python3 scripts/fetch_snet_waveform.py || echo "S-net waveform fetch failed (non-fatal)"
@@ -1112,8 +1112,8 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           FNET_MAX_REQUESTS: ${{ vars.FNET_MAX_REQUESTS || '60' }}
           FNET_MAX_STATIONS: ${{ vars.FNET_MAX_STATIONS || '15' }}
-          # Phase D3: graceful exit ~5min before SIGTERM (timeout-minutes: 75 = 4500s).
-          FNET_STEP_BUDGET_SEC: ${{ vars.FNET_STEP_BUDGET_SEC || '4200' }}
+          # Phase D3: full step budget; script subtracts DEADLINE_MARGIN_SEC=300 (~5min) before SIGTERM at 4500s.
+          FNET_STEP_BUDGET_SEC: ${{ vars.FNET_STEP_BUDGET_SEC || '4500' }}
         run: |
           pip install HinetPy 2>/dev/null || true
           python3 scripts/fetch_fnet_waveform.py || echo "F-net waveform fetch failed (non-fatal)"

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1090,6 +1090,8 @@ jobs:
           HINET_PASS: ${{ secrets.HINET_PASS }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           SNET_MAX_REQUESTS: "60"
+          # Phase D3: graceful exit ~5min before SIGTERM (timeout-minutes: 75 = 4500s).
+          SNET_STEP_BUDGET_SEC: "4200"
         run: |
           pip install HinetPy 2>/dev/null || true
           python3 scripts/fetch_snet_waveform.py || echo "S-net waveform fetch failed (non-fatal)"
@@ -1110,6 +1112,8 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           FNET_MAX_REQUESTS: ${{ vars.FNET_MAX_REQUESTS || '60' }}
           FNET_MAX_STATIONS: ${{ vars.FNET_MAX_STATIONS || '15' }}
+          # Phase D3: graceful exit ~5min before SIGTERM (timeout-minutes: 75 = 4500s).
+          FNET_STEP_BUDGET_SEC: ${{ vars.FNET_STEP_BUDGET_SEC || '4200' }}
         run: |
           pip install HinetPy 2>/dev/null || true
           python3 scripts/fetch_fnet_waveform.py || echo "F-net waveform fetch failed (non-fatal)"

--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -70,6 +70,12 @@ MAX_BACKFILL_DAYS_PER_RUN = 5
 QUOTA_COOLDOWN_SEC = 2
 MAX_REQUESTS_PER_RUN = int(os.environ.get("FNET_MAX_REQUESTS", "60"))
 
+# Phase D3: graceful partial-save before SIGTERM. The GHA step is killed at
+# timeout-minutes (default 75 = 4500 s); we proactively stop ~5 min earlier
+# so per-item saves and the artifact upload step can run cleanly.
+STEP_BUDGET_SEC = int(os.environ.get("FNET_STEP_BUDGET_SEC", "4200"))
+DEADLINE_MARGIN_SEC = int(os.environ.get("FNET_DEADLINE_MARGIN_SEC", "300"))
+
 # Initial active station count (gradual rollout: 15 → 30 → 73).
 # Geographic stratified sample by latitude (N→S) over all available stations.
 MAX_ACTIVE_STATIONS = int(os.environ.get("FNET_MAX_STATIONS", "15"))
@@ -627,14 +633,30 @@ def _check_credentials() -> tuple[str, str] | None:
 
 def _fetch_day(
     client, station_coords: dict, target_date: datetime, n_segments: int,
+    deadline: float | None = None,
 ) -> list[dict]:
-    """Fetch and process one day's F-net waveform data."""
+    """Fetch and process one day's F-net waveform data.
+
+    If ``deadline`` (a ``time.monotonic()`` value) is provided, the segment
+    loop exits early once it is reached, returning whatever results have been
+    accumulated so far so the caller can persist them before SIGTERM.
+    """
     import shutil
     results = []
     date_str = target_date.strftime("%Y-%m-%d")
     segment_hours = [h for h in range(0, 24, max(1, 24 // n_segments))][:n_segments]
+    requested_segments = len(segment_hours)
+    fetched_segments = 0
 
     for hour in segment_hours:
+        if deadline is not None and time.monotonic() >= deadline:
+            logger.warning(
+                "  Step budget exhausted mid-day at %s %02d:00 — fetched %d/%d "
+                "segments, %d records pending caller persist.",
+                date_str, hour, fetched_segments, requested_segments, len(results),
+            )
+            break
+        fetched_segments += 1
         start = target_date.replace(hour=hour, minute=0, second=0, microsecond=0)
         work_dir = tempfile.mkdtemp(prefix=f"fnet_{date_str}_{hour:02d}_")
 
@@ -766,6 +788,10 @@ def _fetch_day(
         finally:
             shutil.rmtree(work_dir, ignore_errors=True)
 
+        # Skip cooldown if it would push us past the deadline (cooldown is
+        # ~QUOTA_COOLDOWN_SEC; SIGTERM during sleep would lose accumulated state).
+        if deadline is not None and time.monotonic() + QUOTA_COOLDOWN_SEC >= deadline:
+            continue
         time.sleep(QUOTA_COOLDOWN_SEC)
 
     return results
@@ -882,8 +908,25 @@ def _fetch_and_save(
     total_items = len(dates_to_fetch)
     request_count = 0
 
+    # Phase D3: graceful exit before SIGTERM. Per-item saves below mean any
+    # data already persisted survives; this loop just stops queueing new items
+    # and the segment loop also bails out via the deadline argument.
+    start_time = time.monotonic()
+    deadline = start_time + STEP_BUDGET_SEC - DEADLINE_MARGIN_SEC
+
     try:
         for i, (target_date, n_segments) in enumerate(dates_to_fetch):
+            now = time.monotonic()
+            if now >= deadline:
+                logger.warning(
+                    "Step budget exhausted at item %d/%d (elapsed %.0fs / "
+                    "budget %ds, margin %ds). Breaking to allow graceful "
+                    "artifact upload.",
+                    i, total_items, now - start_time,
+                    STEP_BUDGET_SEC, DEADLINE_MARGIN_SEC,
+                )
+                break
+
             date_str = target_date.strftime("%Y-%m-%d")
 
             if request_count + n_segments > MAX_REQUESTS_PER_RUN:
@@ -901,6 +944,7 @@ def _fetch_and_save(
             try:
                 day_records = _fetch_day(
                     client, station_coords, target_date, n_segments,
+                    deadline=deadline,
                 )
             except HinetQuotaError as exc:
                 request_count += n_segments
@@ -931,6 +975,9 @@ def _fetch_and_save(
                 _mark_failed_sync(conn, date_str, reason="no_records")
                 logger.info("  Marked %s as failed (no records returned)", date_str)
 
+            # Skip cooldown if it would push us past the deadline.
+            if time.monotonic() + QUOTA_COOLDOWN_SEC >= deadline:
+                continue
             time.sleep(QUOTA_COOLDOWN_SEC)
     finally:
         conn.close()

--- a/scripts/fetch_snet_waveform.py
+++ b/scripts/fetch_snet_waveform.py
@@ -84,6 +84,12 @@ MAX_BACKFILL_DAYS_PER_RUN = 5  # 5 days × 3 codes = 15 backfill requests (reduc
 QUOTA_COOLDOWN_SEC = 2         # Pause between requests to respect quota
 MAX_REQUESTS_PER_RUN = int(os.environ.get("SNET_MAX_REQUESTS", "120"))
 
+# Phase D3: graceful partial-save before SIGTERM. The GHA step is killed at
+# timeout-minutes (default 75 = 4500 s); we proactively stop ~5 min earlier
+# so per-item saves and the artifact upload step can run cleanly.
+STEP_BUDGET_SEC = int(os.environ.get("SNET_STEP_BUDGET_SEC", "4200"))
+DEADLINE_MARGIN_SEC = int(os.environ.get("SNET_DEADLINE_MARGIN_SEC", "300"))
+
 
 class HinetQuotaError(Exception):
     """Raised when HinetPy reports daily quota exceeded.
@@ -663,6 +669,7 @@ def _check_credentials() -> tuple[str, str] | None:
 def _fetch_day(
     client, station_coords: dict, target_date: datetime, n_segments: int,
     network_code: str = "0120A", sensor_config: dict = None,
+    deadline: float | None = None,
 ) -> list[dict]:
     """Fetch and process one day's S-net waveform data for a single sensor code.
 
@@ -678,8 +685,19 @@ def _fetch_day(
     results = []
     date_str = target_date.strftime("%Y-%m-%d")
     segment_hours = [h for h in range(0, 24, max(1, 24 // n_segments))][:n_segments]
+    requested_segments = len(segment_hours)
+    fetched_segments = 0
 
     for hour in segment_hours:
+        if deadline is not None and time.monotonic() >= deadline:
+            logger.warning(
+                "  Step budget exhausted mid-day at %s [%s] %02d:00 -- "
+                "fetched %d/%d segments, %d records pending caller persist.",
+                date_str, network_code, hour, fetched_segments,
+                requested_segments, len(results),
+            )
+            break
+        fetched_segments += 1
         start = target_date.replace(hour=hour, minute=0, second=0, microsecond=0)
         work_dir = tempfile.mkdtemp(prefix=f"snet_{network_code}_{date_str}_{hour:02d}_")
 
@@ -807,7 +825,9 @@ def _fetch_day(
             except Exception:
                 pass
 
-        # Rate limiting
+        # Rate limiting; skip if it would push us past the deadline.
+        if deadline is not None and time.monotonic() + QUOTA_COOLDOWN_SEC >= deadline:
+            continue
         time.sleep(QUOTA_COOLDOWN_SEC)
 
     return results
@@ -926,8 +946,25 @@ def _fetch_and_save(
     total_items = len(dates_to_fetch)
     request_count = 0
 
+    # Phase D3: graceful exit before SIGTERM. Per-item saves below mean any
+    # data already persisted survives; this loop just stops queueing new items
+    # and the segment loop also bails out via the deadline argument.
+    start_time = time.monotonic()
+    deadline = start_time + STEP_BUDGET_SEC - DEADLINE_MARGIN_SEC
+
     try:
         for i, (target_date, n_segments, network_code, sensor_config) in enumerate(dates_to_fetch):
+            now = time.monotonic()
+            if now >= deadline:
+                logger.warning(
+                    "Step budget exhausted at item %d/%d (elapsed %.0fs / "
+                    "budget %ds, margin %ds). Breaking to allow graceful "
+                    "artifact upload.",
+                    i, total_items, now - start_time,
+                    STEP_BUDGET_SEC, DEADLINE_MARGIN_SEC,
+                )
+                break
+
             date_str = target_date.strftime("%Y-%m-%d")
             sensor_type = sensor_config["sensor_type"]
 
@@ -948,6 +985,7 @@ def _fetch_and_save(
                 day_records = _fetch_day(
                     client, station_coords, target_date, n_segments,
                     network_code=network_code, sensor_config=sensor_config,
+                    deadline=deadline,
                 )
             except HinetQuotaError as exc:
                 request_count += n_segments
@@ -984,6 +1022,9 @@ def _fetch_and_save(
                 logger.info("  Marked %s [%s] as failed (no records returned)",
                             date_str, network_code)
 
+            # Skip cooldown if it would push us past the deadline.
+            if time.monotonic() + QUOTA_COOLDOWN_SEC >= deadline:
+                continue
             time.sleep(QUOTA_COOLDOWN_SEC)
     finally:
         conn.close()

--- a/scripts/smoke_test_phase_d3.py
+++ b/scripts/smoke_test_phase_d3.py
@@ -117,5 +117,24 @@ class TestPhaseD3Deadline(unittest.TestCase):
         self.assertEqual(len(client.calls), 4)
 
 
+    def test_snet_fetch_day_breaks_midloop_when_deadline_reached(self):
+        import fetch_snet_waveform as s
+        fake = FakeMonotonic(1000.0)
+        def time_advancing_call():
+            v = fake.now
+            fake.now += 6.0
+            return v
+        with patch.object(s.time, "monotonic", time_advancing_call):
+            client = FakeClient()
+            target = datetime(2026, 4, 28)
+            results = s._fetch_day(
+                client, {}, target, n_segments=4,
+                network_code="0120A",
+                sensor_config={"sensor_type": "accel", "vlf_analysis": False},
+                deadline=1010.0,
+            )
+        self.assertLess(len(client.calls), 4)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/smoke_test_phase_d3.py
+++ b/scripts/smoke_test_phase_d3.py
@@ -1,0 +1,121 @@
+"""Smoke test for Phase D3 graceful partial-save logic.
+
+Pure-unit, no network, no NIED credentials. Mocks HinetPy Client interface
+and time.monotonic so deadline behavior can be exercised deterministically.
+"""
+from __future__ import annotations
+import sys
+import time
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+
+class FakeMonotonic:
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def get_continuous_waveform(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return None
+
+
+class TestPhaseD3Deadline(unittest.TestCase):
+    def setUp(self):
+        self._sleep_patch = patch("time.sleep", lambda *a, **kw: None)
+        self._sleep_patch.start()
+
+    def tearDown(self):
+        self._sleep_patch.stop()
+
+    def test_fnet_constants(self):
+        import fetch_fnet_waveform as f
+        self.assertIsInstance(f.STEP_BUDGET_SEC, int)
+        self.assertIsInstance(f.DEADLINE_MARGIN_SEC, int)
+        self.assertGreater(f.STEP_BUDGET_SEC, f.DEADLINE_MARGIN_SEC)
+
+    def test_snet_constants(self):
+        import fetch_snet_waveform as s
+        self.assertIsInstance(s.STEP_BUDGET_SEC, int)
+        self.assertIsInstance(s.DEADLINE_MARGIN_SEC, int)
+        self.assertGreater(s.STEP_BUDGET_SEC, s.DEADLINE_MARGIN_SEC)
+
+    def test_fnet_fetch_day_breaks_when_deadline_past(self):
+        import fetch_fnet_waveform as f
+        fake = FakeMonotonic(1000.0)
+        with patch.object(f.time, "monotonic", fake):
+            client = FakeClient()
+            target = datetime(2026, 4, 28)
+            results = f._fetch_day(client, {}, target, n_segments=4, deadline=999.0)
+        self.assertEqual(results, [])
+        self.assertEqual(client.calls, [])
+
+    def test_fnet_fetch_day_no_deadline_attempts_all_segments(self):
+        import fetch_fnet_waveform as f
+        client = FakeClient()
+        target = datetime(2026, 4, 28)
+        results = f._fetch_day(client, {}, target, n_segments=4)
+        self.assertEqual(results, [])
+        self.assertEqual(len(client.calls), 4)
+
+    def test_fnet_fetch_day_breaks_midloop_when_deadline_reached(self):
+        import fetch_fnet_waveform as f
+        fake = FakeMonotonic(1000.0)
+        def time_advancing_call():
+            v = fake.now
+            fake.now += 6.0
+            return v
+        with patch.object(f.time, "monotonic", time_advancing_call):
+            client = FakeClient()
+            target = datetime(2026, 4, 28)
+            results = f._fetch_day(
+                client, {}, target, n_segments=4,
+                deadline=1010.0,
+            )
+        self.assertLess(len(client.calls), 4)
+
+    def test_snet_fetch_day_breaks_when_deadline_past(self):
+        import fetch_snet_waveform as s
+        fake = FakeMonotonic(1000.0)
+        with patch.object(s.time, "monotonic", fake):
+            client = FakeClient()
+            target = datetime(2026, 4, 28)
+            results = s._fetch_day(
+                client, {}, target, n_segments=4,
+                network_code="0120A",
+                sensor_config={"sensor_type": "accel", "vlf_analysis": False},
+                deadline=999.0,
+            )
+        self.assertEqual(results, [])
+        self.assertEqual(client.calls, [])
+
+    def test_snet_fetch_day_no_deadline_attempts_all_segments(self):
+        import fetch_snet_waveform as s
+        client = FakeClient()
+        target = datetime(2026, 4, 28)
+        results = s._fetch_day(
+            client, {}, target, n_segments=4,
+            network_code="0120A",
+            sensor_config={"sensor_type": "accel", "vlf_analysis": False},
+        )
+        self.assertEqual(results, [])
+        self.assertEqual(len(client.calls), 4)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

F-net + S-net waveform fetcher が GitHub Actions step `timeout-minutes: 75` で SIGTERM kill された際、`_fetch_day` 内で accumulated `results` が丸ごと損失していた問題への対処 (Phase D3、memory `geohazard-data-completion.md` Phase C 完了後の残作業)。

- **`STEP_BUDGET_SEC`** (default 4200s = 70min) + **`DEADLINE_MARGIN_SEC`** (default 300s = 5min) を両 fetcher に module-level constants で追加 (env override: `FNET_STEP_BUDGET_SEC` / `SNET_STEP_BUDGET_SEC`)。step `timeout-minutes: 75` (= 4500s) より ~5min 前に graceful exit させて artifact upload step を確実に走らせる。
- **`_fetch_and_save` outer loop**: 開始時 `time.monotonic()` で `deadline` を計算、各 item 冒頭で残り時間 check → 切れていれば `break` で graceful exit。
- **`_fetch_day` inner loop**: signature に `deadline: float | None = None` 追加。segment hour loop 冒頭で deadline check → partial `results` を return (caller が `_save_records_sync` で保存)。
- **cooldown skip guard**: deadline 直前で `time.sleep(QUOTA_COOLDOWN_SEC)` が SIGTERM を食わないように、cooldown 完了が deadline を越えるなら skip。
- **`.github/workflows/backfill.yml`**: snet/fnet 各 step の `env:` に `*_STEP_BUDGET_SEC` を thread。`FNET_STEP_BUDGET_SEC` は `${{ vars.FNET_STEP_BUDGET_SEC || '4200' }}` で Repository Variables から override 可能。
- **`scripts/smoke_test_phase_d3.py`** (新規 121 行、unittest): 7 unit tests — fnet/snet constants, deadline-past 即 break, mid-loop break (fetched 2/4 確認), deadline=None backward-compat (4 segments fully attempted)。RPi5 で `7 tests in 0.604s OK` 確認済。

## 既に除外した代替案

- `signal.SIGALRM` per-call timeout — HinetPy 中途状態が不定で SQLite lock リスク
- `asyncio.wait_for(executor_task, ...)` — wait_for 解除後も executor thread 走り続けるため駄目 (memory 確定済)

## Opus subagent 設計レビュー

実装前に subagent でレビュー、(b) Approved with specific changes:
- timing math 4200s - 300s margin で 75min step timeout 内収まる ✅
- signature change: snet 側は `network_code, sensor_config` の **後** に `deadline` 配置 ✅
- partial save: 通常 return path で `_save_records_sync` 経由保存 ✅
- 🔴 quota counter 過大計上の log warning 追加 (mid-day break 時 `fetched %d/%d segments` log) ✅
- cooldown skip guard 追加 ✅

## Test plan

- [ ] CodeRabbit review pass
- [ ] 自リポ即 merge → 次 cron で実戦動作確認 (snet/fnet step が deadline 到達 時に graceful break するか、artifact upload が確実に走るか)
- [ ] Repository Variables に `FNET_STEP_BUDGET_SEC` / `SNET_STEP_BUDGET_SEC` を追加するかは運用上不要 (default で動く)、必要時のみ Settings → Variables で override


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deadline-aware step budgets and graceful shutdown behavior for fetch jobs; introduced environment variables to configure step budgets.

* **Tests**
  * Added unit smoke tests validating deadline/step-budget behavior across fetch workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->