### PR TITLE
feat(workflow): Phase E eliminate non-fatal echo masking (Step 7)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -301,7 +301,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_modis_lst.py || echo "MODIS LST discovery completed"
+          python3 scripts/fetch_modis_lst.py
 
       - name: Snapshot DB
         id: snapshot
@@ -1094,7 +1094,7 @@ jobs:
           SNET_STEP_BUDGET_SEC: "4500"
         run: |
           pip install HinetPy 2>/dev/null || true
-          python3 scripts/fetch_snet_waveform.py || echo "S-net waveform fetch failed (non-fatal)"
+          python3 scripts/fetch_snet_waveform.py
           if [ -f results/snet_coverage.json ]; then
             mkdir -p results/midrun
             cp results/snet_coverage.json results/midrun/
@@ -1116,7 +1116,7 @@ jobs:
           FNET_STEP_BUDGET_SEC: ${{ vars.FNET_STEP_BUDGET_SEC || '4500' }}
         run: |
           pip install HinetPy 2>/dev/null || true
-          python3 scripts/fetch_fnet_waveform.py || echo "F-net waveform fetch failed (non-fatal)"
+          python3 scripts/fetch_fnet_waveform.py
           if [ -f results/fnet_coverage.json ]; then
             mkdir -p results/midrun
             cp results/fnet_coverage.json results/midrun/
@@ -1457,7 +1457,7 @@ jobs:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
           GNSS_TEC_MAX_DATES: "30"
         run: |
-          python3 scripts/fetch_gnss_tec.py || echo "GNSS-TEC fetch non-fatal failure"
+          python3 scripts/fetch_gnss_tec.py
 
       - name: Fetch Kakioka ULF magnetic data
         id: fetch_ulf
@@ -1468,7 +1468,7 @@ jobs:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
           ULF_MAX_DATES: "300"
         run: |
-          python3 scripts/fetch_kakioka_ulf.py || echo "ULF fetch completed"
+          python3 scripts/fetch_kakioka_ulf.py
 
       - name: Fetch NMDB cosmic ray data
         id: fetch_cosmic_ray
@@ -1478,7 +1478,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_nmdb_cosmicray.py || echo "NMDB fetch failed (non-fatal)"
+          python3 scripts/fetch_nmdb_cosmicray.py
 
       - name: Fetch ISS LIS lightning data (Earthdata auth, 2017-2023)
         id: fetch_iss_lis
@@ -1491,7 +1491,7 @@ jobs:
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
-          python3 scripts/fetch_iss_lis_lightning.py || echo "ISS LIS fetch failed (non-fatal)"
+          python3 scripts/fetch_iss_lis_lightning.py
 
       - name: Fetch WWLLN Monthly Thunder Hour (Earthdata auth, 2013-2025)
         id: fetch_wwlln_thunder_hour
@@ -1504,7 +1504,7 @@ jobs:
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
-          python3 scripts/fetch_wwlln_thunder_hour.py || echo "WWLLN thunder-hour fetch failed (non-fatal)"
+          python3 scripts/fetch_wwlln_thunder_hour.py
 
       - name: Fetch LIS/OTD Monthly Climatology Time Series (Earthdata auth, 1995-2014)
         id: fetch_lis_otd_monthly
@@ -1517,7 +1517,7 @@ jobs:
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
-          python3 scripts/fetch_lis_otd_monthly.py || echo "LIS/OTD monthly fetch failed (non-fatal)"
+          python3 scripts/fetch_lis_otd_monthly.py
 
       - name: Fetch INTERMAGNET hourly geomagnetic (CSES portion deprecated 2026-04-26, see fetch_swarm_em)
         id: fetch_geomag
@@ -1540,7 +1540,7 @@ jobs:
           SWARM_TOKEN: ${{ secrets.SWARM_TOKEN }}
           SWARM_MAX_DAYS: "90"
         run: |
-          python3 -u scripts/fetch_swarm_em.py || echo "Swarm EM fetch failed (non-fatal)"
+          python3 -u scripts/fetch_swarm_em.py
 
       - name: Fetch NOAA OLR daily (thermal anomaly)
         id: fetch_olr
@@ -1550,7 +1550,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_olr.py || echo "OLR fetch failed (non-fatal)"
+          python3 scripts/fetch_olr.py
 
       - name: Fetch IERS Earth Orientation Parameters
         id: fetch_iers
@@ -1560,7 +1560,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_iers_eop.py || echo "IERS EOP fetch failed (non-fatal)"
+          python3 scripts/fetch_iers_eop.py
 
       - name: Fetch NASA OMNIWeb solar wind hourly
         id: fetch_solar_wind
@@ -1570,7 +1570,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_solar_wind.py || echo "Solar wind fetch failed (non-fatal)"
+          python3 scripts/fetch_solar_wind.py
 
       - name: Fetch GRACE/GRACE-FO gravity anomaly
         id: fetch_grace
@@ -1583,7 +1583,7 @@ jobs:
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
-          python3 scripts/fetch_grace_gravity.py || echo "GRACE fetch failed (non-fatal)"
+          python3 scripts/fetch_grace_gravity.py
 
       - name: Fetch UHSLC tide gauge data
         id: fetch_tide_gauge
@@ -1593,7 +1593,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_tide_gauge.py || echo "Tide gauge fetch failed (non-fatal)"
+          python3 scripts/fetch_tide_gauge.py
 
       - name: Fetch soil moisture (NOAA CPC monthly + SMOPS daily)
         id: fetch_soil_moisture
@@ -1603,7 +1603,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_smap_moisture.py || echo "Soil moisture fetch failed (non-fatal)"
+          python3 scripts/fetch_smap_moisture.py
 
       - name: Fetch NASA ocean color chlorophyll-a
         id: fetch_ocean_color
@@ -1616,7 +1616,7 @@ jobs:
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
-          python3 scripts/fetch_ocean_color.py || echo "Ocean color fetch failed (non-fatal)"
+          python3 scripts/fetch_ocean_color.py
 
       - name: Fetch VIIRS nighttime light/airglow (Earthdata auth)
         id: fetch_nightlight
@@ -1629,7 +1629,7 @@ jobs:
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
         run: |
-          python3 scripts/fetch_viirs_nighttime.py || echo "VIIRS fetch failed (non-fatal)"
+          python3 scripts/fetch_viirs_nighttime.py
 
       - name: Fetch GOES X-ray flux (solar flares)
         id: fetch_goes_xray
@@ -1639,7 +1639,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_goes_xray.py || echo "GOES X-ray fetch failed (non-fatal)"
+          python3 scripts/fetch_goes_xray.py
 
       - name: Fetch GOES proton flux (SEP events)
         id: fetch_goes_proton
@@ -1649,7 +1649,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_goes_proton.py || echo "GOES proton fetch failed (non-fatal)"
+          python3 scripts/fetch_goes_proton.py
 
       - name: Compute tidal stress (lunar+solar, pure calculation)
         id: fetch_tidal_stress
@@ -1659,7 +1659,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_tidal_stress.py || echo "Tidal stress computation failed (non-fatal)"
+          python3 scripts/fetch_tidal_stress.py
 
       - name: Fetch GOES electron flux (particle precipitation)
         id: fetch_particle_flux
@@ -1669,7 +1669,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_poes_particles.py || echo "Particle flux fetch failed (non-fatal)"
+          python3 scripts/fetch_poes_particles.py
 
       - name: Fetch NOAA DART ocean bottom pressure
         id: fetch_dart
@@ -1679,7 +1679,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_dart_pressure.py || echo "DART pressure fetch failed (non-fatal)"
+          python3 scripts/fetch_dart_pressure.py
 
       - name: Fetch IOC sea level monitoring
         id: fetch_ioc_sealevel
@@ -1689,7 +1689,7 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
-          python3 scripts/fetch_ioc_sealevel.py || echo "IOC sea level fetch failed (non-fatal)"
+          python3 scripts/fetch_ioc_sealevel.py
 
       - name: Snapshot DB for light artifact
         id: snapshot
@@ -1913,6 +1913,7 @@ jobs:
 
       - name: Notify Discord
         if: always()
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           FETCH_EARTHQUAKES: ${{ needs.light.outputs.fetch_earthquakes }}
@@ -1997,7 +1998,7 @@ jobs:
           }]}).encode()
           req = urllib.request.Request(url, data=payload, headers={'Content-Type': 'application/json'})
           urllib.request.urlopen(req)
-          " 2>/dev/null || echo "Discord notification failed (non-fatal)"
+          "
             exit 0
           fi
           python3 -c "
@@ -2132,7 +2133,7 @@ jobs:
           }]}).encode()
           req = urllib.request.Request(url, data=payload, headers={'Content-Type': 'application/json'})
           urllib.request.urlopen(req)
-          " 2>/dev/null || echo "Discord notification failed (non-fatal)"
+          "
 
       # Auto-rerun failed fetch jobs at most ONCE (run_attempt==1 guard prevents
       # infinite loops). Only for scheduled runs -- manual dispatch stays manual.


### PR DESCRIPTION
## Summary

Phase 1 最終残作業 (Step 7)。`backfill.yml` 内の trailing echo masking パターン全廃。

**根本問題**: 各 fetcher 起動行の末尾 echo パターンは shell exit code を 0 に潰していた → `step.outcome=success` が固定 → `continue-on-error: true` + `outputs.fetch_X: steps.X.outcome` の architecture が機能不全 → merge job の `Create issue on failure` (line 2185) で `== 'failure'` 判定が**永遠に matchしない**状態。失敗検出 + Issue 自動作成 + Discord 失敗集計が**完全に死んでいた**。

## Changes (28 件 → 1 件維持)

### Category A: 24 fetcher steps (削除)
`fetch-modis` / `fetch-snet` / `light` job 内の各 fetcher step の末尾 echo を削除。`continue-on-error: true` のみで正しい semantics:
- step は non-zero exit
- `step.outcome=failure` 正しく記録
- `continue-on-error: true` のおかげで workflow は継続
- merge job の集計ロジックが初めて正しく動作

該当 step (24): modis_lst, snet_waveform, fnet_waveform, gnss_tec, ulf, cosmic_ray, iss_lis, wwlln_thunder_hour, lis_otd_monthly, swarm_em, olr, iers, solar_wind, grace, tide_gauge, soil_moisture, ocean_color, nightlight, goes_xray, goes_proton, tidal_stress, particle_flux, dart, ioc_sealevel

### Category B: Notify Discord (continue-on-error 追加 + echo 削除)
- `continue-on-error: true` を Notify Discord step に追加 (元々無かった)
- 2 箇所の `2>/dev/null` + Discord echo 削除 (line ~1998, ~2133)
- 効果: Discord 5xx は step output に visible になり workflow conclusion には影響しない

### Category C: Coverage shell substitution (維持)
line 2305 の `COVERAGE=$(... echo "Coverage unavailable")` は legitimate な fallback。Issue body 用の文字列、削除すると Issue creation 自体が壊れる。

## 期待される副作用

実装後の最初の cron で、これまで silent failure だった真の失敗が表面化:
- 真の fetcher 失敗が `Create issue on failure` step に届くようになる
- `auto-rerun` guard (`!(github.event_name == 'schedule' && github.run_attempt == 1)`) で 1 回目の attempt は issue 作成抑制される
- Discord embed の `failed_steps` list が初めて正しく failure を反映

## Test plan

- [ ] CodeRabbit review pass
- [ ] YAML syntax valid (RPi5 で `yaml.safe_load` 確認済)
- [ ] diff stat: `1 file changed, 27 insertions(+), 26 deletions(-)`
- [ ] `grep -c "|| echo" .github/workflows/backfill.yml` = `1` (Coverage 行のみ残)
- [ ] Notify Discord step に `continue-on-error: true` が挿入されている
- [ ] merge 後、次の cron で Create issue on failure step が発火する条件下なら issue 作成、そうでなければ silent (どちらでも観測可能で OK)

Closes Phase 1 Step 7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow error handling for data fetchers and notifications to improve build step resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->