### PR TITLE
feat(fnet): Phase 2 backfill acceleration (skip-aware loop, newest-first scan, 73 stations, retry reset)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1111,7 +1111,7 @@ jobs:
           HINET_PASS: ${{ secrets.HINET_PASS }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           FNET_MAX_REQUESTS: ${{ vars.FNET_MAX_REQUESTS || '60' }}
-          FNET_MAX_STATIONS: ${{ vars.FNET_MAX_STATIONS || '15' }}
+          FNET_MAX_STATIONS: ${{ vars.FNET_MAX_STATIONS || '73' }}
           # Phase D3: full step budget; script subtracts DEADLINE_MARGIN_SEC=300 (~5min) before SIGTERM at 4500s.
           FNET_STEP_BUDGET_SEC: ${{ vars.FNET_STEP_BUDGET_SEC || '4500' }}
         run: |

--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -66,7 +66,7 @@ REQUEST_DURATION_MIN = 5
 SEGMENTS_RECENT = 4
 SEGMENTS_BACKFILL = 1
 RECENT_DAYS = 7
-MAX_BACKFILL_DAYS_PER_RUN = 5
+MAX_BACKFILL_DAYS_PER_RUN = 30
 QUOTA_COOLDOWN_SEC = 2
 MAX_REQUESTS_PER_RUN = int(os.environ.get("FNET_MAX_REQUESTS", "60"))
 
@@ -116,6 +116,7 @@ VLF_FFT_WINDOW_SEC = 200
 
 EXPECTED_FS = 100.0
 MAX_RETRIES_BEFORE_SKIP = 3
+FAILED_DATES_RETRY_AFTER_DAYS = 30
 
 
 class HinetQuotaError(Exception):
@@ -247,9 +248,13 @@ async def get_failed_dates(
 
         DELETE FROM fnet_failed_dates WHERE date_str = '2018-09-15';
     """
+    cutoff_iso = (
+        datetime.now(timezone.utc) - timedelta(days=FAILED_DATES_RETRY_AFTER_DAYS)
+    ).isoformat()
     rows = await db.execute_fetchall(
-        "SELECT date_str FROM fnet_failed_dates WHERE retry_count >= ?",
-        (threshold,),
+        "SELECT date_str FROM fnet_failed_dates "
+        "WHERE retry_count >= ? AND last_failed_at > ?",
+        (threshold, cutoff_iso),
     )
     return {r[0] for r in rows}
 
@@ -1033,7 +1038,8 @@ async def main() -> None:
         hour=0, minute=0, second=0, microsecond=0, tzinfo=None
     )
     while current >= fnet_start and len(backfill_dates) < MAX_BACKFILL_DAYS_PER_RUN:
-        backfill_dates.append(current)
+        if current.strftime("%Y-%m-%d") not in skip_dates:
+            backfill_dates.append(current)
         current -= timedelta(days=1)
 
     dates_to_fetch = []
@@ -1061,12 +1067,12 @@ async def main() -> None:
         cutoff = (now_utc - timedelta(days=RECENT_DAYS + 1)).replace(
             hour=0, minute=0, second=0, microsecond=0, tzinfo=None
         )
-        scan_date = fnet_start
-        while scan_date <= cutoff:
+        scan_date = cutoff
+        while scan_date >= fnet_start:
             date_str = scan_date.strftime("%Y-%m-%d")
             if date_str not in skip_dates:
                 dates_to_fetch.append((scan_date, SEGMENTS_BACKFILL))
-            scan_date += timedelta(days=1)
+            scan_date -= timedelta(days=1)
 
         if not dates_to_fetch:
             logger.info("No historical gaps found outside recent window.")

--- a/scripts/smoke_test_phase_2_fnet.py
+++ b/scripts/smoke_test_phase_2_fnet.py
@@ -1,0 +1,66 @@
+"""Smoke test for Phase 2 F-net backfill acceleration.
+
+Tests:
+- Constants raised (MAX_BACKFILL_DAYS_PER_RUN, FAILED_DATES_RETRY_AFTER_DAYS).
+- get_failed_dates respects last_failed_at cutoff (older than retry window
+  rolls back into the fetch pool).
+
+No network, no NIED credentials. Uses in-memory aiosqlite.
+"""
+from __future__ import annotations
+import asyncio
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+
+class TestPhase2Constants(unittest.TestCase):
+    def test_max_backfill_days_per_run_raised(self):
+        import fetch_fnet_waveform as f
+        self.assertEqual(f.MAX_BACKFILL_DAYS_PER_RUN, 30)
+
+    def test_failed_dates_retry_after_days_defined(self):
+        import fetch_fnet_waveform as f
+        self.assertGreater(f.FAILED_DATES_RETRY_AFTER_DAYS, 0)
+
+    def test_max_retries_before_skip_unchanged(self):
+        import fetch_fnet_waveform as f
+        self.assertEqual(f.MAX_RETRIES_BEFORE_SKIP, 3)
+
+
+class TestFailedDatesRetryAfterDays(unittest.TestCase):
+    def test_old_failed_date_rolls_back_into_fetch_pool(self):
+        import fetch_fnet_waveform as f
+        import aiosqlite
+
+        async def run():
+            async with aiosqlite.connect(":memory:") as db:
+                await db.execute(f.FAILED_DATES_DDL)
+                now = datetime.now(timezone.utc)
+                old_iso = (now - timedelta(days=f.FAILED_DATES_RETRY_AFTER_DAYS + 5)).isoformat()
+                recent_iso = (now - timedelta(days=5)).isoformat()
+                await db.execute(
+                    "INSERT INTO fnet_failed_dates (date_str, last_failed_at, retry_count, reason) "
+                    "VALUES (?, ?, ?, ?)",
+                    ("2010-01-01", old_iso, 5, "no_records"),
+                )
+                await db.execute(
+                    "INSERT INTO fnet_failed_dates (date_str, last_failed_at, retry_count, reason) "
+                    "VALUES (?, ?, ?, ?)",
+                    ("2024-01-01", recent_iso, 5, "no_records"),
+                )
+                await db.commit()
+
+                skip = await f.get_failed_dates(db)
+                self.assertNotIn("2010-01-01", skip)
+                self.assertIn("2024-01-01", skip)
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`fnet_waveform` テーブルが 13 stations × 12 days = 429 行で停滞し、毎 cron run で `⚠️ F-net Waveform — No Data` 通知が Discord に発射されていた問題を、根本原因 5 点を一括で解消します。

### 根本原因

1. **backfill while ループの skip_dates 判定位置 bug**: 既存日付 5 日分を fixed append → 後で全 skip → window 空 → history scan 起動 → 古い日付 (2000-01) で 0 records → `inserted=0` → 通知発射、を毎 cron 繰り返していました。
2. **history scan が oldest-first**: F-net broadband が実データを持たない 2000 年代前半から scan → fail 確実 → 大量 `failed_dates` 蓄積。
3. **`MAX_ACTIVE_STATIONS=15` で record 数が上限**: HinetPy `get_continuous_waveform` は 1 request で全 station 取得 (12000 channel-min 内) なので 73 まで増やせる余地。
4. **`MAX_BACKFILL_DAYS_PER_RUN=5` で前進が遅い**: 9604 days を埋めるのに 320 日。
5. **`failed_dates` の永久 skip**: 一度 `retry_count >= 3` になると永遠に retry されない。

### 変更内容

| # | 修正 | ファイル |
|---|------|---------|
| A | backfill while ループに `skip_dates` チェックを内側化 (停滞 bug) | `fetch_fnet_waveform.py:1041` |
| B | history scan を `cutoff` から newest-first に反転 | `fetch_fnet_waveform.py:1070-1075` |
| C | `FNET_MAX_STATIONS` default 15 → 73 | `backfill.yml:1114` |
| D | `MAX_BACKFILL_DAYS_PER_RUN` 5 → 30 | `fetch_fnet_waveform.py:69` |
| E | `last_failed_at > now - 30d` 条件追加 (永久 skip 回避) + `FAILED_DATES_RETRY_AFTER_DAYS=30` 定数 | `fetch_fnet_waveform.py:119, 248-260` |
| F | smoke test 4 件追加 (constants 検証 + retry rollback semantics) | `smoke_test_phase_2_fnet.py` (新規) |

### HinetPy quota への影響

`get_continuous_waveform` は network 単位 1 request 設計 (公式 docstring 確認):
- F-net 73 stations × 3 components × 5 min = 1,095 channel-min ≪ 12,000 上限
- 1 request で全 station の指定 hour 分を取得 → station 数を 15 → 73 にしても **request 数は不変、record 数のみ ~5x**

### 期待される挙動変化 (merge 後 1 day)

- recent 7d × 4 segments = 28 + backfill 30d × 1 segment = 58 (`MAX_REQUESTS_PER_RUN=60` 内)
- 1 cron で 30 日分 backfill 前進、6 cron/day なら 180 days/day
- 9604 days 全期間カバーまで ~50 日 (現状 ~320 日見込みから 6x 短縮)
- 30 日経過した failed_dates が retry pool に戻り、F-net broadband 公開範囲が後から拡大した場合に再 fetch

## Test plan

- [x] **`smoke_test_phase_2_fnet.py` 4 件 pass** (定数 3 + retry rollback 動作 1)
- [x] **`smoke_test_phase_d3.py` 8 件 pass** (regression なし)
- [ ] CodeRabbit review pass
- [ ] merge 後 1 cron run 観測:
  - F-net step ログで `Item N/M` の M が 58 (recent 28 + backfill 30) になっている
  - history scan 経路に入った場合は `Item 1/M: 2026-04-XX` (newest-first)
  - `inserted` が 0 でない (record 増分あり)
- [ ] merge 後 24h で `Discord ⚠️ F-net Waveform — No Data` 通知が止まる
- [ ] `fnet_waveform` 行数の推移: 429 → expected 1500+ in 24h (73 stations × 7 recent days × 4 + backfill new days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased default F-net station processing capacity from 15 to 73.

* **New Features**
  * Enhanced failed-data retry logic with time-based cutoff thresholds.
  * Expanded historical backfill processing range from 5 to 30 days per run.

* **Tests**
  * Added smoke test for Phase 2 F-net backfill acceleration to validate configuration and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->