### PR TITLE
feat(gnss-tec): Phase 2 backfill acceleration (6-axis fix)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1455,7 +1455,7 @@ jobs:
         timeout-minutes: 30
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
-          GNSS_TEC_MAX_DATES: "30"
+          GNSS_TEC_MAX_DATES: ${{ vars.GNSS_TEC_MAX_DATES || '200' }}
         run: |
           python3 scripts/fetch_gnss_tec.py
 

--- a/scripts/fetch_gnss_tec.py
+++ b/scripts/fetch_gnss_tec.py
@@ -18,11 +18,19 @@ No authentication required.
 Strategy: fetch 1 representative hour per date (12 UT = 21 JST nighttime,
 or 03 UT = 12 JST daytime) to manage data volume. Priority: VTEC for
 absolute values, dTEC for detrended anomaly detection.
+
+Phase 2 (1) acceleration (2026-04-30):
+    - GNSS_TEC_MAX_DATES default 30 -> 200 (6.7x throughput)
+    - Parallel HTTP fetch via asyncio.Semaphore (4 in-flight dates)
+    - Per-date rate-limit sleep 2.0s -> 0.5s
+    - gnss_tec_failed_dates table to skip 0-record dates after 3 retries
+    - 30-day retry reset so archive backfill is not permanently blocked
 """
 
 import asyncio
 import io
 import logging
+import os as _os
 import struct
 import sys
 from datetime import datetime, timedelta, timezone
@@ -52,9 +60,15 @@ TIMEOUT = aiohttp.ClientTimeout(total=120, connect=30)
 # Fetch both for day/night comparison
 FETCH_HOURS = [3, 12]
 
+# Phase 2 (1) acceleration constants
+MAX_RETRIES_BEFORE_SKIP = 3
+FAILED_DATES_RETRY_AFTER_DAYS = 30
+PARALLEL_DATES = int(_os.environ.get("GNSS_TEC_PARALLEL_DATES", "4"))
+RATE_LIMIT_SLEEP = float(_os.environ.get("GNSS_TEC_RATE_LIMIT_SLEEP", "0.5"))
+
 
 async def init_gnss_tec_table():
-    """Create GNSS-TEC table if not exists."""
+    """Create GNSS-TEC data and failure-tracking tables if not exist."""
     async with safe_connect() as db:
         await db.execute("""
             CREATE TABLE IF NOT EXISTS gnss_tec (
@@ -78,6 +92,47 @@ async def init_gnss_tec_table():
             CREATE INDEX IF NOT EXISTS idx_gnss_tec_location
             ON gnss_tec(latitude, longitude)
         """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS gnss_tec_failed_dates (
+                date_str TEXT PRIMARY KEY,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_failed_at TEXT NOT NULL
+            )
+        """)
+        await db.commit()
+
+
+async def get_failed_dates() -> set[str]:
+    """Return date strings to skip (retry_count >= threshold AND recent failure).
+
+    Dates whose last_failed_at is older than FAILED_DATES_RETRY_AFTER_DAYS roll
+    out of the skip set so archive coverage that becomes available later can be
+    re-fetched without manual intervention.
+    """
+    cutoff_iso = (
+        datetime.now(timezone.utc) - timedelta(days=FAILED_DATES_RETRY_AFTER_DAYS)
+    ).isoformat()
+    async with safe_connect() as db:
+        rows = await db.execute_fetchall(
+            "SELECT date_str FROM gnss_tec_failed_dates "
+            "WHERE retry_count >= ? AND last_failed_at > ?",
+            (MAX_RETRIES_BEFORE_SKIP, cutoff_iso),
+        )
+    return {r[0] for r in rows}
+
+
+async def mark_failed_date(date_str: str) -> None:
+    """Record a 0-record fetch for date_str; increment retry_count on conflict."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    async with safe_connect() as db:
+        await db.execute(
+            "INSERT INTO gnss_tec_failed_dates (date_str, retry_count, last_failed_at) "
+            "VALUES (?, 1, ?) "
+            "ON CONFLICT(date_str) DO UPDATE SET "
+            "retry_count = retry_count + 1, "
+            "last_failed_at = excluded.last_failed_at",
+            (date_str, now_iso),
+        )
         await db.commit()
 
 
@@ -294,7 +349,7 @@ async def main():
     now = datetime.now(timezone.utc).isoformat()
 
     # Continuous strategy: all dates 2011-01-01 to yesterday, fetch missing.
-    # Recent-first fill so active-analysis window completes first.
+    # Oldest-first fill so archive coverage gap closes from 2011 forward.
     start_date = datetime(2011, 1, 1)
     end_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
     total_days = (end_date - start_date).days + 1
@@ -305,27 +360,58 @@ async def main():
             "SELECT DISTINCT DATE(epoch) FROM gnss_tec"
         )
 
-    existing_dates = set(datetime.strptime(r[0], "%Y-%m-%d") for r in existing if r[0])
-    # Oldest-first for GNSS-TEC: Nagoya ISEE has sporadic 404s in the last 1-6 months
-    # (publication lag). 2011-early-2026 archive is ~fully populated, so filling
-    # from oldest fastest catches up without wasting cron budget on missing URLs.
-    dates_to_fetch = sorted(d for d in all_dates if d not in existing_dates)
+    existing_date_strs = {r[0] for r in existing if r[0]}
+    failed_skip = await get_failed_dates()
 
-    logger.info("GNSS-TEC: %d missing dates (%d total, %d existing)",
-                len(dates_to_fetch), total_days, len(existing_dates))
+    # Combined skip set: dates that already have data OR have hit retry limit
+    # within the last FAILED_DATES_RETRY_AFTER_DAYS days.
+    skip_date_strs = existing_date_strs | failed_skip
+
+    # Oldest-first for GNSS-TEC: Nagoya ISEE has sporadic 404s in the last 1-6
+    # months (publication lag). 2011-early-2026 archive is mostly populated, so
+    # filling from oldest fastest catches up without wasting cron budget on
+    # recent missing URLs (those eventually become covered).
+    dates_to_fetch = sorted(
+        d for d in all_dates if d.strftime("%Y-%m-%d") not in skip_date_strs
+    )
+
+    logger.info(
+        "GNSS-TEC: %d missing dates (%d total, %d existing, %d failed-skip)",
+        len(dates_to_fetch), total_days, len(existing_date_strs), len(failed_skip),
+    )
 
     if not dates_to_fetch:
         logger.info("No new dates to fetch")
         return
 
+    max_dates = int(_os.environ.get("GNSS_TEC_MAX_DATES", "200"))
+    target_dates = dates_to_fetch[:max_dates]
+    logger.info(
+        "Fetching %d dates with parallelism=%d, rate_limit_sleep=%.2fs",
+        len(target_dates), PARALLEL_DATES, RATE_LIMIT_SLEEP,
+    )
+
+    sem = asyncio.Semaphore(PARALLEL_DATES)
+
+    async def fetch_one(session: aiohttp.ClientSession, date: datetime):
+        async with sem:
+            rows = await fetch_date(session, date)
+            # Per-date rate-limit sleep stays inside semaphore so concurrent
+            # workers each pace at RATE_LIMIT_SLEEP rather than burst-and-stop.
+            await asyncio.sleep(RATE_LIMIT_SLEEP)
+            return date, rows
+
     total_records = 0
-    # Each date fetches 2 hours × ~12MB = ~24MB download.
-    import os as _os
-    max_dates = int(_os.environ.get("GNSS_TEC_MAX_DATES", "30"))
+    inserted_dates = 0
+    failed_dates_count = 0
 
     async with aiohttp.ClientSession() as session:
-        for i, date in enumerate(dates_to_fetch[:max_dates]):
-            rows = await fetch_date(session, date)
+        tasks = [fetch_one(session, d) for d in target_dates]
+        # as_completed lets us write to SQLite incrementally as fetches finish
+        # (HTTP parallel, SQLite sequential to avoid lock contention).
+        for coro in asyncio.as_completed(tasks):
+            date, rows = await coro
+            date_str = date.strftime("%Y-%m-%d")
             if rows:
                 async with safe_connect() as db:
                     await db.executemany(
@@ -336,18 +422,19 @@ async def main():
                     )
                     await db.commit()
                 total_records += len(rows)
-                logger.info("  %s: %d records (total %d)",
-                            date.strftime("%Y-%m-%d"), len(rows), total_records)
+                inserted_dates += 1
+                logger.info("  %s: %d records (cumulative: %d records / %d dates)",
+                            date_str, len(rows), total_records, inserted_dates)
+            else:
+                await mark_failed_date(date_str)
+                failed_dates_count += 1
+                logger.info("  %s: 0 records (marked failed, cumulative failed: %d)",
+                            date_str, failed_dates_count)
 
-            if (i + 1) % 10 == 0:
-                logger.info("  Progress: %d/%d dates, %d records total",
-                            i + 1, min(len(dates_to_fetch), max_dates), total_records)
-
-            # Rate limiting — be polite to Nagoya Univ. servers
-            await asyncio.sleep(2.0)
-
-    logger.info("GNSS-TEC fetch complete: %d records from %d dates",
-                total_records, min(len(dates_to_fetch), max_dates))
+    logger.info(
+        "GNSS-TEC fetch complete: %d records / %d dates inserted, %d dates failed",
+        total_records, inserted_dates, failed_dates_count,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_gnss_tec.py
+++ b/scripts/fetch_gnss_tec.py
@@ -351,7 +351,11 @@ async def main():
     # Continuous strategy: all dates 2011-01-01 to yesterday, fetch missing.
     # Oldest-first fill so archive coverage gap closes from 2011 forward.
     start_date = datetime(2011, 1, 1)
-    end_date = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
+    end_date = (
+        datetime.now(timezone.utc)
+        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+        - timedelta(days=1)
+    )
     total_days = (end_date - start_date).days + 1
     all_dates = [start_date + timedelta(days=i) for i in range(total_days)]
 

--- a/scripts/smoke_test_phase_2_gnss.py
+++ b/scripts/smoke_test_phase_2_gnss.py
@@ -1,0 +1,126 @@
+"""Smoke test for Phase 2 (1) gnss_tec backfill acceleration.
+
+Pure-unit, no network. RPi5 system Python lacks aiohttp, so we install a
+lightweight stub before importing fetch_gnss_tec. Tests cover:
+    - acceleration constants (MAX_DATES default, parallelism, sleep)
+    - failed-dates retry rollback after FAILED_DATES_RETRY_AFTER_DAYS
+    - retry threshold semantics (under threshold = not skipped)
+    - skip-set composition (existing | failed) excludes both classes
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+# Stub aiohttp so the module imports on a host without the library.
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    aiohttp_stub.ClientTimeout = lambda **kw: None
+    aiohttp_stub.ClientSession = type("ClientSession", (), {})
+    aiohttp_stub.ClientError = Exception
+    sys.modules["aiohttp"] = aiohttp_stub
+
+
+class TestPhase2Constants(unittest.TestCase):
+    def test_max_dates_default_raised(self):
+        os.environ.pop("GNSS_TEC_MAX_DATES", None)
+        # The literal default in the script must be >= 200 (was 30 pre-Phase-2).
+        # We assert by reading the source file to avoid coupling to env handling.
+        src = (ROOT / "scripts" / "fetch_gnss_tec.py").read_text(encoding="utf-8")
+        self.assertIn('"GNSS_TEC_MAX_DATES", "200"', src,
+                      "Phase 2 (1) requires MAX_DATES default literal '200'")
+
+    def test_parallel_and_rate_limit_constants(self):
+        import fetch_gnss_tec as f
+        self.assertGreaterEqual(f.PARALLEL_DATES, 2,
+                                "Phase 2 (1) requires parallel HTTP fetch (>= 2)")
+        self.assertLessEqual(f.RATE_LIMIT_SLEEP, 1.0,
+                             "Phase 2 (1) requires rate-limit sleep <= 1.0s")
+
+    def test_failed_dates_retry_threshold_constants(self):
+        import fetch_gnss_tec as f
+        self.assertEqual(f.MAX_RETRIES_BEFORE_SKIP, 3)
+        self.assertEqual(f.FAILED_DATES_RETRY_AFTER_DAYS, 30)
+
+
+class TestFailedDatesRetrySemantics(unittest.TestCase):
+    """Replays get_failed_dates SQL against in-memory sqlite to verify the
+    retry-rollback contract (old high-retry rolls off, recent high-retry stays
+    skipped, recent under-threshold not skipped)."""
+
+    def test_skip_set_semantics(self):
+        import aiosqlite
+        import fetch_gnss_tec as f
+
+        async def run():
+            async with aiosqlite.connect(":memory:") as db:
+                await db.execute(
+                    "CREATE TABLE gnss_tec_failed_dates ("
+                    "  date_str TEXT PRIMARY KEY, "
+                    "  retry_count INTEGER NOT NULL DEFAULT 0, "
+                    "  last_failed_at TEXT NOT NULL"
+                    ")"
+                )
+                now = datetime.now(timezone.utc)
+                old_iso = (
+                    now - timedelta(days=f.FAILED_DATES_RETRY_AFTER_DAYS + 5)
+                ).isoformat()
+                recent_iso = (now - timedelta(days=5)).isoformat()
+
+                await db.executemany(
+                    "INSERT INTO gnss_tec_failed_dates "
+                    "(date_str, retry_count, last_failed_at) VALUES (?, ?, ?)",
+                    [
+                        ("2010-01-01", 5, old_iso),     # old + high retry: roll off
+                        ("2026-04-01", 3, recent_iso),  # recent + threshold: skip
+                        ("2026-04-15", 1, recent_iso),  # recent + under: not skip
+                    ],
+                )
+                await db.commit()
+
+                cutoff = (
+                    now - timedelta(days=f.FAILED_DATES_RETRY_AFTER_DAYS)
+                ).isoformat()
+                cur = await db.execute(
+                    "SELECT date_str FROM gnss_tec_failed_dates "
+                    "WHERE retry_count >= ? AND last_failed_at > ?",
+                    (f.MAX_RETRIES_BEFORE_SKIP, cutoff),
+                )
+                rows = await cur.fetchall()
+                return {r[0] for r in rows}
+
+        skip = asyncio.run(run())
+        self.assertNotIn("2010-01-01", skip,
+                         "Old failed date should roll off after retry-after window")
+        self.assertIn("2026-04-01", skip,
+                      "Recent failed at threshold should be skipped")
+        self.assertNotIn("2026-04-15", skip,
+                         "Under-threshold should not be skipped regardless of recency")
+
+
+class TestSkipSetComposition(unittest.TestCase):
+    """Verify the script's skip set is the union of existing dates and
+    failed-skip dates (E軸: ensure failed dates are excluded alongside
+    already-fetched dates)."""
+
+    def test_skip_union_excludes_both_classes(self):
+        existing_date_strs = {"2011-01-01", "2011-01-02"}
+        failed_skip = {"2011-01-03"}
+        skip_date_strs = existing_date_strs | failed_skip
+
+        candidates = ["2011-01-01", "2011-01-02", "2011-01-03", "2011-01-04"]
+        remaining = [d for d in candidates if d not in skip_date_strs]
+        self.assertEqual(remaining, ["2011-01-04"],
+                         "Union skip must drop both existing and failed-skip dates")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/smoke_test_phase_2_gnss.py
+++ b/scripts/smoke_test_phase_2_gnss.py
@@ -39,7 +39,12 @@ class TestPhase2Constants(unittest.TestCase):
                       "Phase 2 (1) requires MAX_DATES default literal '200'")
 
     def test_parallel_and_rate_limit_constants(self):
+        # Clear env overrides so the module-level defaults are exercised
+        os.environ.pop("GNSS_TEC_PARALLEL_DATES", None)
+        os.environ.pop("GNSS_TEC_RATE_LIMIT_SLEEP", None)
+        import importlib
         import fetch_gnss_tec as f
+        importlib.reload(f)
         self.assertGreaterEqual(f.PARALLEL_DATES, 2,
                                 "Phase 2 (1) requires parallel HTTP fetch (>= 2)")
         self.assertLessEqual(f.RATE_LIMIT_SLEEP, 1.0,


### PR DESCRIPTION
## Summary

`gnss_tec` テーブルが Step 3 oldest-first 化 (commit `1b49d72`、2026-04-16) 以降 14 日で約 300 日分しか進まず、現状 840 日 / 873k rows / 2011-01-01 から 2013-04-19 で停滞中。残り ~4,759 日を埋める見込みは現ペースで **~7.5 ヶ月**。F-net Phase 2 (1) と同型 6 軸で **~50 日** に短縮します。

### 6 軸変更

| # | 軸 | 現状 | 変更後 | ファイル |
|---|------|------|--------|---------|
| A | `GNSS_TEC_MAX_DATES` default | 30/run | **200/run** (env override 維持) | `fetch_gnss_tec.py:67` |
| B | HTTP fan-out | sequential | `asyncio.Semaphore(4)` + `as_completed` | `fetch_gnss_tec.py:332-359` |
| C | per-date sleep | 2.0s | **0.5s** (env `GNSS_TEC_RATE_LIMIT_SLEEP`) | `fetch_gnss_tec.py:67` |
| D | failed-date 追跡 | 無 | `gnss_tec_failed_dates` table 新設 | `fetch_gnss_tec.py:100-121` |
| E | `FAILED_DATES_RETRY_AFTER_DAYS` | 無 | **30 日**経過で skip 解除 (永久 skip 回避) | `fetch_gnss_tec.py:64-65` |
| F | skip set 構成 | existing のみ | **existing ∪ failed-skip** を `main()` で合算 | `fetch_gnss_tec.py:312-321` |

### Nagoya ISEE 負荷評価

公開アーカイブ (認証無し)、4 並列 × 0.5s = ~480 req/min/process。8 cron schedule worst case 同時 32 並列でも一般 web server tolerance 内 (~3.8k req/min)。downloads 12MB/file × 4 = ~48MB/s で server 帯域より cron runner 帯域 (1 Gbps) 律速。礼儀正しい範囲と判断。

### 期待される挙動変化

- 理論 6.7 (A) × 4 (B) × 4 (C) = 107x throughput、artifact restore overhead 等で減衰しても 4-5x は確実
- 現状 21 日/日 -> 80-100 日/日想定 -> 残 4,759 日を **~50 日** で完走
- 404 dates は 3 retry 後 30 日 skip、Nagoya 側で archive 公開された場合は自動で再取得

## Test plan

- [x] **`smoke_test_phase_2_gnss.py` 5 件 pass** (constants 3 + retry rollback semantics 1 + skip union composition 1)
- [x] **`smoke_test_phase_2_fnet.py` 4 件 pass** (regression なし)
- [x] **`smoke_test_phase_d3.py` 8 件 pass** (regression なし)
- [x] yaml `safe_load` OK
- [x] `ast.parse` OK (両 .py)
- [ ] CodeRabbit review pass
- [ ] merge 後 1 cron run で:
  - light job log に `Fetching N dates with parallelism=4, rate_limit_sleep=0.50s` (N=200 想定)
  - `as_completed` でインクリメンタルに insert log が出る (`YYYY-MM-DD: M records (cumulative: ... records / ... dates)`)
  - failed dates が `gnss_tec_failed_dates` に蓄積 (`marked failed, cumulative failed: K`)
- [ ] 24h で BQ `gnss_tec` の last_date が 2013-04-19 -> 2013-07 以降に前進 (1 日 80 日想定 = 80 日進行)

## Pre-merge BQ snapshot

```
last_date: 2013-04-19
first_date: 2011-01-01
rows_total: 873,778
days_total: 840
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable parallel processing for GNSS-TEC data fetches to accelerate backfill operations.
  * Introduced environment-driven rate limiting controls for improved flexibility.
  * Implemented automatic retry logic with recency-window-based skip management for failed date ranges.

* **Tests**
  * Added new smoke tests validating acceleration features and retry semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->