### PR TITLE
feat(ioc_sealevel): backfill oldest-first from 2011 with parallelism

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1688,6 +1688,8 @@ jobs:
         timeout-minutes: 15
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
+          IOC_PARALLEL_FETCHES: ${{ vars.IOC_PARALLEL_FETCHES || '2' }}
+          IOC_RATE_LIMIT_SLEEP: ${{ vars.IOC_RATE_LIMIT_SLEEP || '1.0' }}
           IOC_MAX_FETCHES: ${{ vars.IOC_MAX_FETCHES || '200' }}
         run: |
           python3 scripts/fetch_ioc_sealevel.py

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1688,6 +1688,7 @@ jobs:
         timeout-minutes: 15
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
+          IOC_MAX_FETCHES: ${{ vars.IOC_MAX_FETCHES || '200' }}
         run: |
           python3 scripts/fetch_ioc_sealevel.py
 

--- a/scripts/fetch_ioc_sealevel.py
+++ b/scripts/fetch_ioc_sealevel.py
@@ -32,7 +32,9 @@ References:
 """
 
 import asyncio
+import json
 import logging
+import os
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -57,21 +59,25 @@ JAPAN_LAT_MAX = 50.0
 JAPAN_LON_MIN = 120.0
 JAPAN_LON_MAX = 155.0
 
-# How many days of recent data to fetch per station
-FETCH_DAYS = 45
-
 # Maximum number of stations to process (time budget constraint)
 MAX_STATIONS = 30
+
+# Backfill start date — IOC SLSMF historical data is broadly available from 2011
+BACKFILL_START = datetime(2011, 1, 1)
 
 MAX_RETRIES = 3
 TIMEOUT = aiohttp.ClientTimeout(total=300, connect=60)
 
-# Delay between station data requests (rate limit compliance)
-REQUEST_DELAY_SEC = 1.0
+# Phase 2 (1) acceleration constants (gnss_tec PR #114 と同型)
+MAX_RETRIES_BEFORE_SKIP = 3
+FAILED_DATES_RETRY_AFTER_DAYS = 30
+PARALLEL_FETCHES = int(os.environ.get("IOC_PARALLEL_FETCHES", "2"))
+RATE_LIMIT_SLEEP = float(os.environ.get("IOC_RATE_LIMIT_SLEEP", "1.0"))
+MAX_FETCHES = int(os.environ.get("IOC_MAX_FETCHES", "200"))
 
 
 async def init_ioc_sealevel_table():
-    """Create IOC sea level table and indices."""
+    """Create IOC sea level data and failure-tracking tables and indices."""
     async with safe_connect() as db:
         await db.execute("""
             CREATE TABLE IF NOT EXISTS ioc_sea_level (
@@ -94,7 +100,65 @@ async def init_ioc_sealevel_table():
             CREATE INDEX IF NOT EXISTS idx_ioc_sealevel_station
             ON ioc_sea_level(station_code)
         """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS ioc_sealevel_failed_dates (
+                station_code TEXT NOT NULL,
+                date_str TEXT NOT NULL,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                last_failed_at TEXT NOT NULL,
+                PRIMARY KEY (station_code, date_str)
+            )
+        """)
         await db.commit()
+
+
+async def get_failed_pairs() -> set[tuple[str, str]]:
+    """Return (station_code, date_str) pairs to skip on this run.
+
+    Pairs whose last_failed_at is older than FAILED_DATES_RETRY_AFTER_DAYS roll
+    out of the skip set so previously-empty dates that become available later
+    can be re-fetched without manual intervention.
+    """
+    cutoff_iso = (
+        datetime.now(timezone.utc) - timedelta(days=FAILED_DATES_RETRY_AFTER_DAYS)
+    ).isoformat()
+    async with safe_connect() as db:
+        rows = await db.execute_fetchall(
+            "SELECT station_code, date_str FROM ioc_sealevel_failed_dates "
+            "WHERE retry_count >= ? AND last_failed_at > ?",
+            (MAX_RETRIES_BEFORE_SKIP, cutoff_iso),
+        )
+    return {(r[0], r[1]) for r in rows}
+
+
+async def mark_failed_pair(station_code: str, date_str: str) -> None:
+    """Record a 0-record fetch for (station_code, date_str); increment retry_count."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    async with safe_connect() as db:
+        await db.execute(
+            "INSERT INTO ioc_sealevel_failed_dates "
+            "(station_code, date_str, retry_count, last_failed_at) "
+            "VALUES (?, ?, 1, ?) "
+            "ON CONFLICT(station_code, date_str) DO UPDATE SET "
+            "retry_count = retry_count + 1, "
+            "last_failed_at = excluded.last_failed_at",
+            (station_code, date_str, now_iso),
+        )
+        await db.commit()
+
+
+async def get_existing_dates_per_station() -> dict[str, set[str]]:
+    """Return {station_code: {date_str, ...}} computed from existing rows."""
+    async with safe_connect() as db:
+        rows = await db.execute_fetchall(
+            "SELECT station_code, DATE(observed_at) AS d "
+            "FROM ioc_sea_level GROUP BY station_code, d"
+        )
+    existing: dict[str, set[str]] = {}
+    for code, d in rows:
+        if d:
+            existing.setdefault(code, set()).add(d)
+    return existing
 
 
 async def fetch_station_list(session: aiohttp.ClientSession) -> list[dict]:
@@ -220,7 +284,7 @@ async def fetch_station_data(session: aiohttp.ClientSession,
                               station: dict,
                               time_start: str,
                               time_stop: str) -> list[dict]:
-    """Fetch sea level data for one IOC station.
+    """Fetch sea level data for one IOC station within a time range.
 
     Args:
         session: aiohttp session.
@@ -245,24 +309,15 @@ async def fetch_station_data(session: aiohttp.ClientSession,
                     text = await resp.text()
                     # Handle empty or non-JSON responses
                     if not text.strip() or text.strip().startswith("<"):
-                        logger.info("  %s (%s): empty or HTML response",
-                                    station["code"], station["name"])
                         return []
-                    import json
                     try:
                         data = json.loads(text)
                     except json.JSONDecodeError:
-                        logger.info("  %s (%s): invalid JSON",
-                                    station["code"], station["name"])
                         return []
                     if not isinstance(data, list):
-                        logger.info("  %s (%s): unexpected format",
-                                    station["code"], station["name"])
                         return []
                     return parse_ioc_data(data, station)
                 elif resp.status == 404:
-                    logger.info("  %s (%s): not available (404)",
-                                station["code"], station["name"])
                     return []
                 else:
                     if attempt == MAX_RETRIES:
@@ -277,25 +332,41 @@ async def fetch_station_data(session: aiohttp.ClientSession,
     return []
 
 
+def build_target_pairs(
+    all_dates: list[datetime],
+    stations: list[dict],
+    existing_per_station: dict[str, set[str]],
+    failed_pairs: set[tuple[str, str]],
+    max_fetches: int,
+) -> list[tuple[datetime, dict]]:
+    """Compute oldest-first (date, station) pairs to fetch this run.
+
+    Iterates dates outermost so all stations advance together rather than one
+    station racing ahead. Skips pairs already in existing rows or in the
+    failed-dates retry-skip set.
+    """
+    target: list[tuple[datetime, dict]] = []
+    for date in all_dates:
+        date_str = date.strftime("%Y-%m-%d")
+        for station in stations:
+            code = station["code"]
+            if date_str in existing_per_station.get(code, set()):
+                continue
+            if (code, date_str) in failed_pairs:
+                continue
+            target.append((date, station))
+            if len(target) >= max_fetches:
+                return target
+    return target
+
+
 async def main():
+    """Backfill IOC sea level data oldest-first from 2011 across all stations."""
     await init_db()
     await init_ioc_sealevel_table()
 
     now = datetime.now(timezone.utc)
     now_iso = now.isoformat()
-
-    # Time window for data fetch
-    time_start = (now - timedelta(days=FETCH_DAYS)).strftime("%Y-%m-%d %H:%M:%S")
-    time_stop = now.strftime("%Y-%m-%d %H:%M:%S")
-
-    # Check existing data summary
-    async with safe_connect() as db:
-        existing = await db.execute_fetchall(
-            "SELECT station_code, COUNT(*), MAX(observed_at) "
-            "FROM ioc_sea_level GROUP BY station_code"
-        )
-    existing_summary = {r[0]: (r[1], r[2]) for r in existing} if existing else {}
-    logger.info("IOC sea level existing: %d stations", len(existing_summary))
 
     # Fetch station list
     async with aiohttp.ClientSession() as session:
@@ -305,49 +376,94 @@ async def main():
         logger.warning("No IOC stations found in Japan area; aborting")
         return
 
-    # Fetch data for each station
+    existing_per_station = await get_existing_dates_per_station()
+    failed_pairs = await get_failed_pairs()
+
+    # Build target date list (BACKFILL_START .. yesterday UTC)
+    end_date = (
+        datetime.now(timezone.utc)
+        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+        - timedelta(days=1)
+    )
+    total_days = (end_date - BACKFILL_START).days + 1
+    all_dates = [BACKFILL_START + timedelta(days=i) for i in range(total_days)]
+
+    target_pairs = build_target_pairs(
+        all_dates, stations, existing_per_station, failed_pairs, MAX_FETCHES,
+    )
+
+    total_existing_pairs = sum(len(s) for s in existing_per_station.values())
+    logger.info(
+        "IOC sea level: %d stations, %d existing (station, date) pairs, %d failed-skip pairs",
+        len(stations), total_existing_pairs, len(failed_pairs),
+    )
+    logger.info(
+        "Fetching %d (date, station) pairs with parallelism=%d, rate_limit_sleep=%.2fs",
+        len(target_pairs), PARALLEL_FETCHES, RATE_LIMIT_SLEEP,
+    )
+
+    if not target_pairs:
+        logger.info("No new (date, station) pairs to fetch")
+        return
+
+    sem = asyncio.Semaphore(PARALLEL_FETCHES)
+
+    async def fetch_one(session: aiohttp.ClientSession,
+                         date: datetime, station: dict):
+        async with sem:
+            date_str = date.strftime("%Y-%m-%d")
+            time_start = f"{date_str} 00:00:00"
+            time_stop = f"{date_str} 23:59:59"
+            rows = await fetch_station_data(
+                session, station, time_start, time_stop,
+            )
+            # Per-fetch rate-limit sleep stays inside semaphore so concurrent
+            # workers each pace at RATE_LIMIT_SLEEP rather than burst-and-stop.
+            await asyncio.sleep(RATE_LIMIT_SLEEP)
+            return date, station, rows
+
     total_records = 0
-    stations_with_data = 0
+    inserted_pairs = 0
+    failed_count = 0
 
     async with aiohttp.ClientSession() as session:
-        for station in stations:
-            logger.info("Fetching %s (%s, %.2f°N %.2f°E)...",
-                        station["code"], station["name"],
-                        station["lat"], station["lon"])
+        tasks = [fetch_one(session, d, s) for d, s in target_pairs]
+        for coro in asyncio.as_completed(tasks):
+            date, station, rows = await coro
+            date_str = date.strftime("%Y-%m-%d")
+            code = station["code"]
+            if rows:
+                async with safe_connect() as db:
+                    await db.executemany(
+                        """INSERT OR IGNORE INTO ioc_sea_level
+                           (station_code, station_name, observed_at,
+                            sea_level_m, latitude, longitude, received_at)
+                           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                        [(code, station["name"], r["observed_at"],
+                          r["sea_level_m"], station["lat"], station["lon"],
+                          now_iso) for r in rows],
+                    )
+                    await db.commit()
+                total_records += len(rows)
+                inserted_pairs += 1
+                if inserted_pairs % 20 == 0 or inserted_pairs <= 5:
+                    logger.info(
+                        "  %s/%s: %d records (cumulative: %d records / %d pairs)",
+                        code, date_str, len(rows), total_records, inserted_pairs,
+                    )
+            else:
+                await mark_failed_pair(code, date_str)
+                failed_count += 1
+                if failed_count % 20 == 0 or failed_count <= 5:
+                    logger.info(
+                        "  %s/%s: 0 records (marked failed, cumulative failed: %d)",
+                        code, date_str, failed_count,
+                    )
 
-            rows = await fetch_station_data(
-                session, station, time_start, time_stop
-            )
-
-            if not rows:
-                logger.info("  %s: no data returned", station["code"])
-                await asyncio.sleep(REQUEST_DELAY_SEC)
-                continue
-
-            # Store in database
-            async with safe_connect() as db:
-                await db.executemany(
-                    """INSERT OR IGNORE INTO ioc_sea_level
-                       (station_code, station_name, observed_at,
-                        sea_level_m, latitude, longitude, received_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    [(station["code"], station["name"], r["observed_at"],
-                      r["sea_level_m"], station["lat"], station["lon"],
-                      now_iso) for r in rows],
-                )
-                await db.commit()
-
-            total_records += len(rows)
-            stations_with_data += 1
-            logger.info("  %s: %d records (%.2f - %.2f m)",
-                        station["name"], len(rows),
-                        min(r["sea_level_m"] for r in rows),
-                        max(r["sea_level_m"] for r in rows))
-
-            await asyncio.sleep(REQUEST_DELAY_SEC)
-
-    logger.info("IOC sea level fetch complete: %d records from %d/%d stations",
-                total_records, stations_with_data, len(stations))
+    logger.info(
+        "IOC sea level fetch complete: %d records / %d pairs inserted, %d pairs failed",
+        total_records, inserted_pairs, failed_count,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_ioc_sealevel.py
+++ b/scripts/fetch_ioc_sealevel.py
@@ -345,6 +345,8 @@ def build_target_pairs(
     station racing ahead. Skips pairs already in existing rows or in the
     failed-dates retry-skip set.
     """
+    if max_fetches <= 0:
+        return []
     target: list[tuple[datetime, dict]] = []
     for date in all_dates:
         date_str = date.strftime("%Y-%m-%d")

--- a/scripts/smoke_test_phase_2_ioc.py
+++ b/scripts/smoke_test_phase_2_ioc.py
@@ -1,0 +1,176 @@
+"""Smoke test for Phase 2 (1) ioc_sea_level backfill acceleration.
+
+Pure-unit, no network. RPi5 system Python lacks aiohttp, so we install a
+lightweight stub before importing fetch_ioc_sealevel. Tests cover:
+    - acceleration constants (MAX_FETCHES default, parallelism, sleep)
+    - failed-pairs retry rollback after FAILED_DATES_RETRY_AFTER_DAYS
+    - retry threshold semantics (under threshold = not skipped)
+    - build_target_pairs respects existing + failed skip sets and max cap
+    - build_target_pairs emits oldest-first across all stations
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+# Stub aiohttp so the module imports on a host without the library.
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    aiohttp_stub.ClientTimeout = lambda **kw: None
+    aiohttp_stub.ClientSession = type("ClientSession", (), {})
+    aiohttp_stub.ClientError = Exception
+    sys.modules["aiohttp"] = aiohttp_stub
+
+
+class TestPhase2Constants(unittest.TestCase):
+    def test_max_fetches_default_raised(self):
+        os.environ.pop("IOC_MAX_FETCHES", None)
+        src = (ROOT / "scripts" / "fetch_ioc_sealevel.py").read_text(encoding="utf-8")
+        self.assertIn('"IOC_MAX_FETCHES", "200"', src,
+                      "Phase 2 (1) requires MAX_FETCHES default literal '200'")
+
+    def test_parallel_and_rate_limit_constants(self):
+        os.environ.pop("IOC_PARALLEL_FETCHES", None)
+        os.environ.pop("IOC_RATE_LIMIT_SLEEP", None)
+        import importlib
+        import fetch_ioc_sealevel as f
+        importlib.reload(f)
+        self.assertGreaterEqual(f.PARALLEL_FETCHES, 2,
+                                "Phase 2 (1) requires parallel HTTP fetch (>= 2)")
+        self.assertLessEqual(f.RATE_LIMIT_SLEEP, 1.0,
+                             "Phase 2 (1) requires rate-limit sleep <= 1.0s")
+        self.assertEqual(f.BACKFILL_START.year, 2011,
+                         "Backfill must start from 2011-01-01")
+
+    def test_failed_dates_retry_threshold_constants(self):
+        import fetch_ioc_sealevel as f
+        self.assertEqual(f.MAX_RETRIES_BEFORE_SKIP, 3)
+        self.assertEqual(f.FAILED_DATES_RETRY_AFTER_DAYS, 30)
+
+
+class TestFailedPairsRetrySemantics(unittest.TestCase):
+    """Replay get_failed_pairs SQL against in-memory sqlite to verify the
+    retry-rollback contract for the (station_code, date_str) composite key."""
+
+    def test_skip_pair_set_semantics(self):
+        import aiosqlite
+        import fetch_ioc_sealevel as f
+
+        async def run():
+            async with aiosqlite.connect(":memory:") as db:
+                await db.execute(
+                    "CREATE TABLE ioc_sealevel_failed_dates ("
+                    "  station_code TEXT NOT NULL, "
+                    "  date_str TEXT NOT NULL, "
+                    "  retry_count INTEGER NOT NULL DEFAULT 0, "
+                    "  last_failed_at TEXT NOT NULL, "
+                    "  PRIMARY KEY (station_code, date_str)"
+                    ")"
+                )
+                now = datetime.now(timezone.utc)
+                old_iso = (
+                    now - timedelta(days=f.FAILED_DATES_RETRY_AFTER_DAYS + 5)
+                ).isoformat()
+                recent_iso = (now - timedelta(days=5)).isoformat()
+
+                await db.executemany(
+                    "INSERT INTO ioc_sealevel_failed_dates "
+                    "(station_code, date_str, retry_count, last_failed_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    [
+                        ("ofun", "2010-01-01", 5, old_iso),     # roll off
+                        ("ofun", "2026-04-01", 3, recent_iso),  # skip
+                        ("ofun", "2026-04-15", 1, recent_iso),  # not skip
+                        ("hana", "2026-04-01", 5, recent_iso),  # skip
+                    ],
+                )
+                await db.commit()
+
+                cutoff = (
+                    now - timedelta(days=f.FAILED_DATES_RETRY_AFTER_DAYS)
+                ).isoformat()
+                cur = await db.execute(
+                    "SELECT station_code, date_str FROM ioc_sealevel_failed_dates "
+                    "WHERE retry_count >= ? AND last_failed_at > ?",
+                    (f.MAX_RETRIES_BEFORE_SKIP, cutoff),
+                )
+                rows = await cur.fetchall()
+                return {(r[0], r[1]) for r in rows}
+
+        skip = asyncio.run(run())
+        self.assertNotIn(("ofun", "2010-01-01"), skip,
+                         "Old failed pair should roll off after retry window")
+        self.assertIn(("ofun", "2026-04-01"), skip,
+                      "Recent failed pair at threshold should be skipped")
+        self.assertNotIn(("ofun", "2026-04-15"), skip,
+                         "Under-threshold pair should not be skipped")
+        self.assertIn(("hana", "2026-04-01"), skip,
+                      "Per-station composite key must skip independently")
+
+
+class TestBuildTargetPairs(unittest.TestCase):
+    """Cover build_target_pairs: skip composition + ordering + cap."""
+
+    def test_skip_excludes_existing_and_failed(self):
+        import fetch_ioc_sealevel as f
+        all_dates = [
+            datetime(2011, 1, 1),
+            datetime(2011, 1, 2),
+            datetime(2011, 1, 3),
+        ]
+        stations = [
+            {"code": "ofun", "name": "Ofunato", "lat": 39.0, "lon": 141.7},
+            {"code": "hana", "name": "Hanasaki", "lat": 43.3, "lon": 145.6},
+        ]
+        existing_per_station = {"ofun": {"2011-01-01"}}
+        failed_pairs = {("hana", "2011-01-02")}
+
+        pairs = f.build_target_pairs(
+            all_dates, stations, existing_per_station, failed_pairs, max_fetches=99,
+        )
+        codes_dates = [(s["code"], d.strftime("%Y-%m-%d")) for d, s in pairs]
+
+        self.assertNotIn(("ofun", "2011-01-01"), codes_dates,
+                         "Existing date for station must be excluded")
+        self.assertNotIn(("hana", "2011-01-02"), codes_dates,
+                         "Failed pair must be excluded")
+        # Remaining 5 = total 6 - 2 skipped pairs (one existing, one failed)
+        self.assertEqual(len(pairs), 4,
+                         "Expected 4 pairs after skipping 2 of 6 candidates")
+
+    def test_oldest_first_across_stations(self):
+        import fetch_ioc_sealevel as f
+        all_dates = [datetime(2011, 1, 1), datetime(2011, 1, 2)]
+        stations = [
+            {"code": "a", "name": "A", "lat": 0.0, "lon": 0.0},
+            {"code": "b", "name": "B", "lat": 0.0, "lon": 0.0},
+        ]
+        pairs = f.build_target_pairs(all_dates, stations, {}, set(), max_fetches=99)
+        codes_dates = [(s["code"], d.strftime("%Y-%m-%d")) for d, s in pairs]
+        self.assertEqual(
+            codes_dates,
+            [("a", "2011-01-01"), ("b", "2011-01-01"),
+             ("a", "2011-01-02"), ("b", "2011-01-02")],
+            "Pairs must iterate dates outermost so all stations advance together",
+        )
+
+    def test_max_fetches_cap(self):
+        import fetch_ioc_sealevel as f
+        all_dates = [datetime(2011, 1, i) for i in range(1, 11)]
+        stations = [{"code": f"s{i}", "name": "x", "lat": 0.0, "lon": 0.0}
+                    for i in range(5)]
+        pairs = f.build_target_pairs(all_dates, stations, {}, set(), max_fetches=3)
+        self.assertEqual(len(pairs), 3,
+                         "max_fetches must cap the returned pair count")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/smoke_test_phase_2_ioc.py
+++ b/scripts/smoke_test_phase_2_ioc.py
@@ -171,6 +171,14 @@ class TestBuildTargetPairs(unittest.TestCase):
         self.assertEqual(len(pairs), 3,
                          "max_fetches must cap the returned pair count")
 
+    def test_max_fetches_zero_returns_empty(self):
+        import fetch_ioc_sealevel as f
+        all_dates = [datetime(2011, 1, 1)]
+        stations = [{"code": "a", "name": "x", "lat": 0.0, "lon": 0.0}]
+        pairs = f.build_target_pairs(all_dates, stations, {}, set(), max_fetches=0)
+        self.assertEqual(pairs, [],
+                         "max_fetches=0 must short-circuit before any append")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Phase 2 (1) ioc_sea_level backfill acceleration mirroring gnss_tec PR #114.

- Replace fixed `FETCH_DAYS=45` with oldest-first per-day fetch from 2011-01-01.
- Add `IOC_PARALLEL_FETCHES` (default 2), `IOC_RATE_LIMIT_SLEEP` (default 1.0), `IOC_MAX_FETCHES` (default 200, workflow vars override).
- Add `ioc_sealevel_failed_dates` table (PK `station_code, date_str`) with 30-day retry-skip rollback.
- New `build_target_pairs` helper iterates dates outermost so all stations advance together.

## Background
IOC SLSMF API was probed against historical `timestart=2020-01-01`: returned 1-min cadence records, confirming the fixed 45-day window was the only reason past coverage stopped at 34 days in the existing 637K row baseline.

## Smoke
`scripts/smoke_test_phase_2_ioc.py`: 7 unit tests covering constants (defaults, retry threshold), failed-pairs retry rollback semantics with composite PK, `build_target_pairs` skip composition, oldest-first ordering, max cap. All 7 pass on Local Py3.12.

## Expected impact
30 stations x 200 fetches/cron x 8 cron/day = 1600 fetches/day. Per-station catch-up rate ~53 days/day, full 2011-now span backfilled in ~100 days. Concurrent with gnss_tec PR #114 still running.

## Test plan
- [ ] Next scheduled cron after merge: light job log shows the new \"Fetching N (date, station) pairs\" line.
- [ ] Subsequent crons: BQ \`ioc_sea_level\` row count grows beyond 637K and \`MIN(observed_at)\` moves earlier than 2026-03-12.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable data fetch limits for backfill operations
  * Concurrent data fetching capability for improved efficiency
  * Enhanced retry mechanism for failed requests with persistent tracking
* **Tests**
  * Added comprehensive test suite for backfill workflow validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->