### PR TITLE
feat(fetchers): classify transient vs definitive errors (Phase 2 (1) Stage 1)

### DIFF
--- a/scripts/fetch_gnss_tec.py
+++ b/scripts/fetch_gnss_tec.py
@@ -25,6 +25,13 @@ Phase 2 (1) acceleration (2026-04-30):
     - Per-date rate-limit sleep 2.0s -> 0.5s
     - gnss_tec_failed_dates table to skip 0-record dates after 3 retries
     - 30-day retry reset so archive backfill is not permanently blocked
+
+Phase 2 (1) Stage 1 (2026-05-02): transient vs definitive error classification.
+    HTTP 5xx / Timeout / ConnectionError after MAX_RETRIES are now treated as
+    transient (TRANSIENT_FAILURE sentinel) and skipped without marking the
+    date in gnss_tec_failed_dates. Only definitive 200-OK-empty / 404 results
+    increment retry_count. Prevents legitimate dates from getting 30-day
+    blacklisted by transient infra errors.
 """
 
 import asyncio
@@ -65,6 +72,23 @@ MAX_RETRIES_BEFORE_SKIP = 3
 FAILED_DATES_RETRY_AFTER_DAYS = 30
 PARALLEL_DATES = int(_os.environ.get("GNSS_TEC_PARALLEL_DATES", "4"))
 RATE_LIMIT_SLEEP = float(_os.environ.get("GNSS_TEC_RATE_LIMIT_SLEEP", "0.5"))
+
+
+class _TransientFailure:
+    """Sentinel marker for transient HTTP failures (5xx, timeouts, conn errors).
+
+    Distinguished from None (definitive 404 / no-data) so the main loop can
+    skip marking the date in gnss_tec_failed_dates and rely on the next cron
+    to retry without burning a retry_count slot.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<TRANSIENT_FAILURE>"
+
+
+TRANSIENT_FAILURE = _TransientFailure()
 
 
 async def init_gnss_tec_table():
@@ -136,8 +160,18 @@ async def mark_failed_date(date_str: str) -> None:
         await db.commit()
 
 
-async def try_fetch(session: aiohttp.ClientSession, url: str) -> bytes | None:
-    """Try to fetch a URL, return None on failure."""
+async def try_fetch(
+    session: aiohttp.ClientSession, url: str,
+) -> "bytes | None | _TransientFailure":
+    """Try to fetch a URL.
+
+    Returns:
+        bytes:               HTTP 200 with body.
+        None:                HTTP 404 (definitive no-data — archive gap).
+        TRANSIENT_FAILURE:   HTTP 5xx / 429 / timeout / connection error after
+                             MAX_RETRIES retries. Caller should NOT advance
+                             failed_dates retry_count (next cron retries).
+    """
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             async with session.get(url, timeout=TIMEOUT) as resp:
@@ -146,13 +180,18 @@ async def try_fetch(session: aiohttp.ClientSession, url: str) -> bytes | None:
                 elif resp.status == 404:
                     return None
                 else:
+                    # 5xx / 429 / other non-success — backoff and retry,
+                    # surface as transient on final attempt.
                     logger.debug("HTTP %d for %s", resp.status, url.split("/")[-1])
+                    if attempt == MAX_RETRIES:
+                        return TRANSIENT_FAILURE
+                    await asyncio.sleep(2 ** attempt)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             if attempt == MAX_RETRIES:
-                logger.debug("Failed: %s", e)
-                return None
+                logger.debug("Transient failure: %s", e)
+                return TRANSIENT_FAILURE
             await asyncio.sleep(2 ** attempt)
-    return None
+    return TRANSIENT_FAILURE
 
 
 def parse_netcdf_simple(data: bytes, epoch: str) -> list[tuple]:
@@ -300,11 +339,26 @@ def _grid_to_rows(lats, lons, tec_data, epoch: str) -> list[tuple]:
     return rows
 
 
-async def fetch_date(session: aiohttp.ClientSession, date: datetime,
-                     hours: list[int] | None = None) -> list[tuple]:
-    """Fetch GNSS-TEC data for a specific date.
+async def fetch_date(
+    session: aiohttp.ClientSession, date: datetime,
+    hours: list[int] | None = None,
+) -> "list[tuple] | None | _TransientFailure":
+    """Fetch GNSS-TEC data for a specific date with hour-grain status.
 
-    Tries VTEC (AGRID2) first, then dTEC (GRID2) as fallback.
+    Tries VTEC (AGRID2) first, then dTEC (GRID2) as fallback per hour.
+
+    Returns:
+        list[tuple]:        At least one hour produced records (any partial
+                            success). Definitive 404 hours are silently
+                            skipped — they may be filled by a future archive
+                            update but never block the date from being marked
+                            "fetched" since at least some data was obtained.
+        None:               All hours returned definitive 404 with zero parsed
+                            rows. Caller marks date in gnss_tec_failed_dates
+                            so retry_count can advance.
+        TRANSIENT_FAILURE:  At least one hour saw 5xx/timeout/conn error and
+                            no hour produced records. Caller does NOT mark —
+                            next cron will retry cleanly.
     """
     if hours is None:
         hours = FETCH_HOURS
@@ -313,32 +367,45 @@ async def fetch_date(session: aiohttp.ClientSession, date: datetime,
     doy = date.strftime("%j")
     ymd = date.strftime("%Y%m%d")
 
-    all_rows = []
+    all_rows: list[tuple] = []
+    saw_transient = False
 
     for hour in hours:
         hh = f"{hour:02d}"
         epoch = f"{date.strftime('%Y-%m-%d')} {hh}:00:00"
 
+        hour_rows: list[tuple] = []
+
         # Try VTEC (absolute TEC) — available from 1993
         url = f"{NAGOYA_BASE}/AGRID2/nc/{year}/{doy}/{ymd}{hh}_atec.nc"
         data = await try_fetch(session, url)
-        if data is not None and len(data) > 100:
-            rows = parse_netcdf_simple(data, epoch)
-            if rows:
-                all_rows.extend(rows)
-                logger.info("  %s %s UT: %d VTEC records", date.strftime("%Y-%m-%d"), hh, len(rows))
+        if data is TRANSIENT_FAILURE:
+            saw_transient = True
+        elif data is not None and len(data) > 100:
+            hour_rows = parse_netcdf_simple(data, epoch)
+            if hour_rows:
+                all_rows.extend(hour_rows)
+                logger.info("  %s %s UT: %d VTEC records",
+                            date.strftime("%Y-%m-%d"), hh, len(hour_rows))
                 continue
 
         # Fallback: dTEC (detrended) — available from 2019
         url = f"{NAGOYA_BASE}/GRID2/nc/{year}/{doy}/{ymd}{hh}_dtec.nc"
         data = await try_fetch(session, url)
-        if data is not None and len(data) > 100:
-            rows = parse_netcdf_simple(data, epoch)
-            if rows:
-                all_rows.extend(rows)
-                logger.info("  %s %s UT: %d dTEC records", date.strftime("%Y-%m-%d"), hh, len(rows))
+        if data is TRANSIENT_FAILURE:
+            saw_transient = True
+        elif data is not None and len(data) > 100:
+            hour_rows = parse_netcdf_simple(data, epoch)
+            if hour_rows:
+                all_rows.extend(hour_rows)
+                logger.info("  %s %s UT: %d dTEC records",
+                            date.strftime("%Y-%m-%d"), hh, len(hour_rows))
 
-    return all_rows
+    if all_rows:
+        return all_rows
+    if saw_transient:
+        return TRANSIENT_FAILURE
+    return None
 
 
 async def main():
@@ -408,6 +475,7 @@ async def main():
     total_records = 0
     inserted_dates = 0
     failed_dates_count = 0
+    transient_skipped = 0
 
     async with aiohttp.ClientSession() as session:
         tasks = [fetch_one(session, d) for d in target_dates]
@@ -416,7 +484,15 @@ async def main():
         for coro in asyncio.as_completed(tasks):
             date, rows = await coro
             date_str = date.strftime("%Y-%m-%d")
-            if rows:
+            if rows is TRANSIENT_FAILURE:
+                # Don't advance retry_count — next cron retries cleanly.
+                transient_skipped += 1
+                if transient_skipped <= 5 or transient_skipped % 20 == 0:
+                    logger.info(
+                        "  %s: transient failure (not marked, cumulative: %d)",
+                        date_str, transient_skipped,
+                    )
+            elif rows:
                 async with safe_connect() as db:
                     await db.executemany(
                         """INSERT OR IGNORE INTO gnss_tec
@@ -430,14 +506,17 @@ async def main():
                 logger.info("  %s: %d records (cumulative: %d records / %d dates)",
                             date_str, len(rows), total_records, inserted_dates)
             else:
+                # Definitive no-data (None): all hours returned 404 with no
+                # parsed rows. Advance retry_count.
                 await mark_failed_date(date_str)
                 failed_dates_count += 1
                 logger.info("  %s: 0 records (marked failed, cumulative failed: %d)",
                             date_str, failed_dates_count)
 
     logger.info(
-        "GNSS-TEC fetch complete: %d records / %d dates inserted, %d dates failed",
-        total_records, inserted_dates, failed_dates_count,
+        "GNSS-TEC fetch complete: %d records / %d dates inserted, "
+        "%d dates failed (definitive), %d dates transient-skipped",
+        total_records, inserted_dates, failed_dates_count, transient_skipped,
     )
 
 

--- a/scripts/fetch_ioc_sealevel.py
+++ b/scripts/fetch_ioc_sealevel.py
@@ -76,6 +76,25 @@ RATE_LIMIT_SLEEP = float(os.environ.get("IOC_RATE_LIMIT_SLEEP", "1.0"))
 MAX_FETCHES = int(os.environ.get("IOC_MAX_FETCHES", "200"))
 
 
+class _TransientFailure:
+    """Sentinel marker for transient HTTP failures (5xx, timeouts, conn errors,
+    HTML error pages, JSON decode errors).
+
+    Distinguished from an empty list (definitive 200-OK no-data / 404) so the
+    main loop can skip marking the (station, date) pair in
+    ioc_sealevel_failed_dates and rely on the next cron to retry without
+    burning a retry_count slot.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<TRANSIENT_FAILURE>"
+
+
+TRANSIENT_FAILURE = _TransientFailure()
+
+
 async def init_ioc_sealevel_table():
     """Create IOC sea level data and failure-tracking tables and indices."""
     async with safe_connect() as db:
@@ -280,10 +299,12 @@ def parse_ioc_data(data: list, station: dict) -> list[dict]:
     return rows
 
 
-async def fetch_station_data(session: aiohttp.ClientSession,
-                              station: dict,
-                              time_start: str,
-                              time_stop: str) -> list[dict]:
+async def fetch_station_data(
+    session: aiohttp.ClientSession,
+    station: dict,
+    time_start: str,
+    time_stop: str,
+) -> "list[dict] | _TransientFailure":
     """Fetch sea level data for one IOC station within a time range.
 
     Args:
@@ -292,7 +313,17 @@ async def fetch_station_data(session: aiohttp.ClientSession,
         time_start: start time string (YYYY-MM-DD HH:MM:SS).
         time_stop: end time string (YYYY-MM-DD HH:MM:SS).
 
-    Returns list of parsed records.
+    Returns:
+        list[dict]:        Parsed records (possibly empty for definitive
+                           200-OK no-data or 404). Caller marks the (station,
+                           date) pair in ioc_sealevel_failed_dates only when
+                           the list is empty.
+        TRANSIENT_FAILURE: 5xx / 429 / timeout / connection error after
+                           MAX_RETRIES, or 200-OK with HTML error page /
+                           JSON decode error / non-list payload (IOC SLSMF
+                           returns HTML during overload — treating as
+                           transient avoids 30-day blacklist of legitimate
+                           dates).
     """
     params = {
         "query": "data",
@@ -307,29 +338,65 @@ async def fetch_station_data(session: aiohttp.ClientSession,
             async with session.get(IOC_BASE, params=params, timeout=TIMEOUT) as resp:
                 if resp.status == 200:
                     text = await resp.text()
-                    # Handle empty or non-JSON responses
-                    if not text.strip() or text.strip().startswith("<"):
+                    stripped = text.strip()
+                    if not stripped:
+                        # 200 OK with empty body — IOC convention for genuine
+                        # gaps.
                         return []
+                    if stripped.startswith("<"):
+                        # HTML error page returned with 200 OK (overload /
+                        # gateway error). Transient.
+                        if attempt == MAX_RETRIES:
+                            logger.warning(
+                                "  %s (%s): 200 OK with HTML body (transient)",
+                                station["code"], station["name"],
+                            )
+                            return TRANSIENT_FAILURE
+                        await asyncio.sleep(2 ** attempt)
+                        continue
                     try:
                         data = json.loads(text)
                     except json.JSONDecodeError:
-                        return []
+                        # 200 OK but unparseable — server-side glitch, retry.
+                        if attempt == MAX_RETRIES:
+                            logger.warning(
+                                "  %s (%s): JSON decode error (transient)",
+                                station["code"], station["name"],
+                            )
+                            return TRANSIENT_FAILURE
+                        await asyncio.sleep(2 ** attempt)
+                        continue
                     if not isinstance(data, list):
-                        return []
+                        # Unexpected payload shape — surface as transient so
+                        # we revisit; if the API permanently changes shape,
+                        # ops will see persistent transient_skipped counts.
+                        if attempt == MAX_RETRIES:
+                            logger.warning(
+                                "  %s (%s): non-list payload %s (transient)",
+                                station["code"], station["name"],
+                                type(data).__name__,
+                            )
+                            return TRANSIENT_FAILURE
+                        await asyncio.sleep(2 ** attempt)
+                        continue
                     return parse_ioc_data(data, station)
                 elif resp.status == 404:
                     return []
                 else:
+                    # 5xx / 429 / other — backoff, surface transient on final.
                     if attempt == MAX_RETRIES:
-                        logger.warning("  %s (%s): HTTP %d",
+                        logger.warning("  %s (%s): HTTP %d (transient)",
                                        station["code"], station["name"], resp.status)
+                        return TRANSIENT_FAILURE
+                    await asyncio.sleep(2 ** attempt)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             if attempt == MAX_RETRIES:
-                logger.warning("  %s (%s): %s",
+                logger.warning("  %s (%s): %s (transient)",
                                station["code"], station["name"], type(e).__name__)
+                return TRANSIENT_FAILURE
             await asyncio.sleep(2 ** attempt)
 
-    return []
+    return TRANSIENT_FAILURE
 
 
 def build_target_pairs(
@@ -427,6 +494,7 @@ async def main():
     total_records = 0
     inserted_pairs = 0
     failed_count = 0
+    transient_skipped = 0
 
     async with aiohttp.ClientSession() as session:
         tasks = [fetch_one(session, d, s) for d, s in target_pairs]
@@ -434,7 +502,15 @@ async def main():
             date, station, rows = await coro
             date_str = date.strftime("%Y-%m-%d")
             code = station["code"]
-            if rows:
+            if rows is TRANSIENT_FAILURE:
+                # Don't advance retry_count — next cron retries cleanly.
+                transient_skipped += 1
+                if transient_skipped <= 5 or transient_skipped % 20 == 0:
+                    logger.info(
+                        "  %s/%s: transient failure (not marked, cumulative: %d)",
+                        code, date_str, transient_skipped,
+                    )
+            elif rows:
                 async with safe_connect() as db:
                     await db.executemany(
                         """INSERT OR IGNORE INTO ioc_sea_level
@@ -454,6 +530,7 @@ async def main():
                         code, date_str, len(rows), total_records, inserted_pairs,
                     )
             else:
+                # Definitive empty list (200 OK + empty body, or 404).
                 await mark_failed_pair(code, date_str)
                 failed_count += 1
                 if failed_count % 20 == 0 or failed_count <= 5:
@@ -463,8 +540,9 @@ async def main():
                     )
 
     logger.info(
-        "IOC sea level fetch complete: %d records / %d pairs inserted, %d pairs failed",
-        total_records, inserted_pairs, failed_count,
+        "IOC sea level fetch complete: %d records / %d pairs inserted, "
+        "%d pairs failed (definitive), %d pairs transient-skipped",
+        total_records, inserted_pairs, failed_count, transient_skipped,
     )
 
 

--- a/scripts/smoke_test_phase_2_error_classification.py
+++ b/scripts/smoke_test_phase_2_error_classification.py
@@ -1,0 +1,309 @@
+"""Smoke test for Phase 2 (1) Stage 1 transient vs definitive error classification.
+
+Pure-unit, no network. Mocks aiohttp ClientSession to simulate scenarios:
+    - HTTP 200 + valid payload     → records list (definitive success)
+    - HTTP 200 + empty body        → []                (definitive no-data)
+    - HTTP 200 + HTML error page   → TRANSIENT_FAILURE (retry next cron)
+    - HTTP 200 + JSON decode error → TRANSIENT_FAILURE (retry next cron)
+    - HTTP 200 + non-list payload  → TRANSIENT_FAILURE (retry next cron)
+    - HTTP 404                     → []                (definitive 404)
+    - HTTP 5xx (3 retries)         → TRANSIENT_FAILURE
+    - HTTP 429 (3 retries)         → TRANSIENT_FAILURE
+    - asyncio.TimeoutError x3      → TRANSIENT_FAILURE
+    - ConnectionError x3           → TRANSIENT_FAILURE
+    - 5xx -> 200 (recovery)        → records list
+
+Verifies the 3-way return contract that lets the main loop:
+    - skip mark_failed_* on transient (so retry_count is preserved)
+    - mark on definitive empty so the 30-day blacklist works as designed
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+# Stub aiohttp so module imports on a host without the library. We mock the
+# real network entrypoints (session.get) per-test below; the stubbed
+# ClientError is used as the base for ConnectionError simulation.
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+    aiohttp_stub.ClientTimeout = lambda **kw: None
+    aiohttp_stub.ClientSession = type("ClientSession", (), {})
+    aiohttp_stub.ClientError = type("ClientError", (Exception,), {})
+    sys.modules["aiohttp"] = aiohttp_stub
+
+
+def _make_resp(status: int, text_body: str | None = None,
+               bytes_body: bytes | None = None):
+    """Build an async-context-manager-shaped response mock for session.get(...)."""
+    resp = AsyncMock()
+    resp.status = status
+    if text_body is not None:
+        resp.text = AsyncMock(return_value=text_body)
+    if bytes_body is not None:
+        resp.read = AsyncMock(return_value=bytes_body)
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def _session_with_responses(side_effects):
+    """Build a fake aiohttp.ClientSession whose .get() returns the queued cms.
+
+    Each side_effects element is either:
+        - a context-manager mock (callable that returns it on .get())
+        - an Exception instance to raise
+    """
+    session = AsyncMock()
+    queue = list(side_effects)
+
+    def get(*_a, **_kw):
+        item = queue.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    session.get = get
+    return session
+
+
+class TestIOCErrorClassification(unittest.TestCase):
+    """fetch_ioc_sealevel.fetch_station_data return contract."""
+
+    def setUp(self):
+        import fetch_ioc_sealevel as f
+        self.f = f
+        self.station = {"code": "ofun", "name": "Ofunato",
+                        "lat": 39.0, "lon": 141.7}
+
+    def _run_fetch(self, side_effects):
+        async def go():
+            with patch("asyncio.sleep", new=AsyncMock(return_value=None)):
+                session = _session_with_responses(side_effects)
+                return await self.f.fetch_station_data(
+                    session, self.station,
+                    "2011-01-01 00:00:00", "2011-01-01 23:59:59",
+                )
+        return asyncio.run(go())
+
+    def test_200_valid_json_returns_records(self):
+        body = '[{"stime": "2011-01-01 00:00:00", "slevel": "1.234"}]'
+        result = self._run_fetch([_make_resp(200, text_body=body)])
+        self.assertIsInstance(result, list, "200 OK + JSON → list")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["sea_level_m"], 1.234)
+
+    def test_200_empty_body_returns_empty_list(self):
+        result = self._run_fetch([_make_resp(200, text_body="")])
+        self.assertEqual(result, [],
+                         "200 OK + empty body must be definitive (mark failed)")
+        self.assertIsNot(result, self.f.TRANSIENT_FAILURE)
+
+    def test_200_html_body_returns_transient(self):
+        html = "<html><body>Service Temporarily Unavailable</body></html>"
+        result = self._run_fetch([_make_resp(200, text_body=html)] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE,
+                      "200 OK + HTML must be transient (server overload pattern)")
+
+    def test_200_invalid_json_returns_transient(self):
+        result = self._run_fetch([_make_resp(200, text_body="not json {")] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE,
+                      "200 OK + JSON decode error must be transient")
+
+    def test_200_non_list_payload_returns_transient(self):
+        result = self._run_fetch([_make_resp(200, text_body='{"err": "x"}')] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE,
+                      "200 OK + non-list payload must be transient")
+
+    def test_404_returns_empty_list(self):
+        result = self._run_fetch([_make_resp(404)])
+        self.assertEqual(result, [], "404 must be definitive empty")
+        self.assertIsNot(result, self.f.TRANSIENT_FAILURE)
+
+    def test_503_three_times_returns_transient(self):
+        result = self._run_fetch([_make_resp(503)] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE,
+                      "Persistent 5xx must be transient (don't burn retry_count)")
+
+    def test_429_three_times_returns_transient(self):
+        result = self._run_fetch([_make_resp(429)] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE,
+                      "Persistent 429 must be transient")
+
+    def test_timeout_three_times_returns_transient(self):
+        result = self._run_fetch([asyncio.TimeoutError()] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE)
+
+    def test_connection_error_three_times_returns_transient(self):
+        import aiohttp
+        result = self._run_fetch([aiohttp.ClientError("conn refused")] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE)
+
+    def test_503_then_200_recovers(self):
+        body = '[{"stime": "2011-01-01 00:00:00", "slevel": "0.5"}]'
+        result = self._run_fetch([
+            _make_resp(503),
+            _make_resp(200, text_body=body),
+        ])
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1, "5xx then 200 must recover within retries")
+
+
+class TestGNSSErrorClassification(unittest.TestCase):
+    """fetch_gnss_tec.try_fetch return contract."""
+
+    def setUp(self):
+        import fetch_gnss_tec as f
+        self.f = f
+
+    def _run_fetch(self, side_effects):
+        async def go():
+            with patch("asyncio.sleep", new=AsyncMock(return_value=None)):
+                session = _session_with_responses(side_effects)
+                return await self.f.try_fetch(session, "https://example/x.nc")
+        return asyncio.run(go())
+
+    def test_200_returns_bytes(self):
+        result = self._run_fetch([_make_resp(200, bytes_body=b"CDF\x01" + b"x" * 200)])
+        self.assertIsInstance(result, bytes)
+        self.assertGreater(len(result), 100)
+
+    def test_404_returns_none(self):
+        result = self._run_fetch([_make_resp(404)])
+        self.assertIsNone(result, "404 = definitive no-data (None)")
+        self.assertIsNot(result, self.f.TRANSIENT_FAILURE)
+
+    def test_503_three_times_returns_transient(self):
+        result = self._run_fetch([_make_resp(503)] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE)
+
+    def test_timeout_three_times_returns_transient(self):
+        result = self._run_fetch([asyncio.TimeoutError()] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE)
+
+    def test_connection_error_three_times_returns_transient(self):
+        import aiohttp
+        result = self._run_fetch([aiohttp.ClientError("conn refused")] * 3)
+        self.assertIs(result, self.f.TRANSIENT_FAILURE)
+
+    def test_503_then_200_recovers(self):
+        result = self._run_fetch([
+            _make_resp(503),
+            _make_resp(200, bytes_body=b"CDF\x01" + b"x" * 200),
+        ])
+        self.assertIsInstance(result, bytes)
+
+
+class TestGNSSFetchDateAggregation(unittest.TestCase):
+    """fetch_gnss_tec.fetch_date hour-grain status aggregation contract."""
+
+    def setUp(self):
+        import fetch_gnss_tec as f
+        self.f = f
+
+    def _patched_run(self, try_fetch_returns,
+                     parse_returns=None):
+        """Run fetch_date with try_fetch and parse_netcdf_simple monkey-patched."""
+        from datetime import datetime as _dt
+        try_fetch_calls = iter(try_fetch_returns)
+        parse_calls = iter(parse_returns or [])
+
+        async def fake_try_fetch(_session, _url):
+            return next(try_fetch_calls)
+
+        def fake_parse(_data, _epoch):
+            try:
+                return next(parse_calls)
+            except StopIteration:
+                return []
+
+        async def go():
+            with patch.object(self.f, "try_fetch", new=fake_try_fetch), \
+                 patch.object(self.f, "parse_netcdf_simple", new=fake_parse):
+                # FETCH_HOURS = [3, 12] → 2 hours × 2 URLs = up to 4 try_fetch calls
+                return await self.f.fetch_date(
+                    AsyncMock(),  # session, unused since try_fetch is faked
+                    _dt(2011, 1, 1),
+                )
+        return asyncio.run(go())
+
+    def test_all_hours_404_returns_none(self):
+        # 4 try_fetch calls (2 hours × {VTEC, dTEC}), all 404.
+        result = self._patched_run([None, None, None, None])
+        self.assertIsNone(result,
+                          "All-404 must be definitive (mark failed)")
+
+    def test_all_hours_transient_returns_transient(self):
+        T = self.f.TRANSIENT_FAILURE
+        result = self._patched_run([T, T, T, T])
+        self.assertIs(result, T,
+                      "All-transient must surface as TRANSIENT_FAILURE")
+
+    def test_partial_success_returns_records(self):
+        big = b"CDF\x01" + b"x" * 200
+        # Hour 3: VTEC returns bytes (records). Hour 12: VTEC 404, dTEC 404.
+        result = self._patched_run(
+            try_fetch_returns=[big, None, None],
+            parse_returns=[[(35.0, 140.0, 12.5, None, "2011-01-01 03:00:00")]],
+        )
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1,
+                         "Partial success returns merged records list")
+
+    def test_transient_then_404_no_records_returns_transient(self):
+        T = self.f.TRANSIENT_FAILURE
+        # Hour 3: VTEC TRANSIENT, dTEC TRANSIENT. Hour 12: VTEC 404, dTEC 404.
+        result = self._patched_run([T, T, None, None])
+        self.assertIs(result, T,
+                      "Mix of TRANSIENT + 404 with no records must be TRANSIENT")
+
+    def test_one_hour_data_one_hour_transient_returns_records(self):
+        big = b"CDF\x01" + b"x" * 200
+        # Hour 3: VTEC returns bytes (records). Hour 12: TRANSIENT, TRANSIENT.
+        result = self._patched_run(
+            try_fetch_returns=[big, self.f.TRANSIENT_FAILURE,
+                               self.f.TRANSIENT_FAILURE],
+            parse_returns=[[(35.0, 140.0, 12.5, None, "2011-01-01 03:00:00")]],
+        )
+        self.assertIsInstance(result, list,
+                              "Any hour with records → list (not transient)")
+        self.assertEqual(len(result), 1)
+
+
+class TestSentinelDistinctness(unittest.TestCase):
+    """TRANSIENT_FAILURE must be distinguishable from None / [] / 0 / False."""
+
+    def test_ioc_sentinel_is_not_falsy_or_list_or_none(self):
+        import fetch_ioc_sealevel as f
+        self.assertIsNot(f.TRANSIENT_FAILURE, None)
+        self.assertIsNot(f.TRANSIENT_FAILURE, [])
+        self.assertNotEqual(f.TRANSIENT_FAILURE, [])
+        self.assertNotEqual(f.TRANSIENT_FAILURE, None)
+
+    def test_gnss_sentinel_is_not_falsy_or_list_or_none(self):
+        import fetch_gnss_tec as f
+        self.assertIsNot(f.TRANSIENT_FAILURE, None)
+        self.assertIsNot(f.TRANSIENT_FAILURE, [])
+        self.assertNotEqual(f.TRANSIENT_FAILURE, [])
+        self.assertNotEqual(f.TRANSIENT_FAILURE, None)
+
+    def test_sentinels_are_independent_per_module(self):
+        """Each module owns its own sentinel — `is` must not cross-match."""
+        import fetch_ioc_sealevel as f_ioc
+        import fetch_gnss_tec as f_gnss
+        # Independent sentinels by design — keeps each fetcher's main loop
+        # from accidentally accepting a foreign module's sentinel.
+        self.assertIsNot(f_ioc.TRANSIENT_FAILURE, f_gnss.TRANSIENT_FAILURE)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

CodeRabbit Round 1 actionable #2 follow-up from PR #114 (gnss_tec) and PR #116 (ioc_sea_level).

Both fetchers were marking dates/pairs as failed on **transient** HTTP errors (5xx, timeouts, connection errors), burning a slot in the 3-strikes-then-30-day-blacklist counter for legitimately reachable data. A handful of unlucky cron runs could put a perfectly fine archive date into a 30-day dead zone.

## Design

Per-module \`TRANSIENT_FAILURE\` sentinel + 3-way return contract:

- \`list\` / \`bytes\`  → definitive success, insert
- \`[]\` / \`None\`    → definitive no-data (200 OK empty body, or 404), mark failed (advance retry_count)
- \`TRANSIENT\`      → skip without marking, next cron retries with retry_count untouched

Transient classification covers:
- HTTP 5xx / 429 after \`MAX_RETRIES\`
- \`asyncio.TimeoutError\` / \`aiohttp.ClientError\` after \`MAX_RETRIES\`
- 200 OK + HTML error page (IOC SLSMF returns HTML during overload)
- 200 OK + \`JSONDecodeError\`
- 200 OK + non-list payload

For \`gnss_tec\` the aggregation is **hour-grain** inside \`fetch_date\`:
- any hour with records → return merged list (partial success counts as success)
- all 404 → return \`None\` (definitive no-data, mark)
- any TRANSIENT + zero records → return \`TRANSIENT\` (don't mark)

## Side fix

\`fetch_gnss_tec.try_fetch\` non-200/non-404 branch was missing the \`asyncio.sleep(2 ** attempt)\` backoff (only the \`except\` branch had it), so persistent 5xx ran 3 attempts back-to-back. Now backs off on every attempt.

## Existing false-positive entries

Left to clear via the 30-day \`FAILED_DATES_RETRY_AFTER_DAYS\` natural rollover. **No automatic reset** — risks unmarking genuine archive gaps. If we want a one-off cleanup later, a \`scripts/reset_failed_dates.py --since YYYY-MM-DD --dry-run\` opt-in script is the cleaner path.

## Smoke test

New \`scripts/smoke_test_phase_2_error_classification.py\` (25 tests):

- **IOC** (\`fetch_station_data\`): 200+JSON, 200+empty, 200+HTML, 200+invalid JSON, 200+non-list, 404, 503x3, 429x3, Timeout x3, ConnectionError x3, 503→200 recovery
- **GNSS** (\`try_fetch\`): 200, 404, 503x3, Timeout x3, Conn x3, 503→200 recovery
- **GNSS** (\`fetch_date\` aggregation): all-404, all-transient, partial success, transient+404, hour-data + hour-transient
- **Sentinel distinctness**: not equal to \`None\`/\`[]\`, cross-module independence

\`asyncio.sleep\` is patched out so tests run in 0.22s.

All **42 smoke tests pass** (25 new + 8 existing IOC + 5 existing GNSS + 4 existing F-net).

## Test plan

- [x] Smoke unit tests (42 / 42 pass)
- [ ] Cron run with transient_skipped count surfaced in summary log
- [ ] Verify \`failed_dates\` / \`failed_pairs\` row count growth slows after merge