### PR TITLE
feat(cleanup): add --skip-sqlite for BQ-only hosts (RPi5 unblock)

### DIFF
--- a/scripts/cleanup_ioc_sealevel_dart.py
+++ b/scripts/cleanup_ioc_sealevel_dart.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -95,6 +96,14 @@ def _parse_args() -> argparse.Namespace:
         "--skip-bq", action="store_true",
         help="Skip BigQuery DELETE (sqlite-only cleanup).",
     )
+    p.add_argument(
+        "--skip-sqlite", action="store_true",
+        help=(
+            "Skip sqlite inspect/DELETE. Use this when ioc_sea_level only "
+            "exists in BigQuery (e.g. RPi5 host where the IOC fetcher runs "
+            "on a GHA runner and writes to BQ directly)."
+        ),
+    )
     return p.parse_args()
 
 
@@ -123,20 +132,37 @@ def _build_bq_where(codes: list[str], min_date: str | None,
 
 
 async def _sqlite_inspect(codes: list[str], min_date: str | None,
-                          max_date: str | None) -> dict:
+                          max_date: str | None) -> dict | None:
+    """Inspect contaminated rows in sqlite.
+
+    Returns None when ioc_sea_level / ioc_sealevel_failed_dates are absent
+    from this sqlite (e.g. a host where the IOC fetcher never wrote here).
+    Caller treats None as "nothing to do in sqlite — proceed to BQ".
+    """
     where, params = _build_sqlite_where(codes, min_date, max_date)
-    async with safe_connect() as db:
-        rows = await db.execute_fetchall(
-            f"SELECT station_code, COUNT(*) FROM ioc_sea_level "
-            f"WHERE {where} GROUP BY station_code ORDER BY station_code",
-            params,
-        )
-        failed_rows = await db.execute_fetchall(
-            f"SELECT station_code, COUNT(*) FROM ioc_sealevel_failed_dates "
-            f"WHERE station_code IN ({','.join(['?'] * len(codes))}) "
-            f"GROUP BY station_code",
-            list(codes),
-        )
+    try:
+        async with safe_connect() as db:
+            rows = await db.execute_fetchall(
+                f"SELECT station_code, COUNT(*) FROM ioc_sea_level "
+                f"WHERE {where} GROUP BY station_code ORDER BY station_code",
+                params,
+            )
+            failed_rows = await db.execute_fetchall(
+                f"SELECT station_code, COUNT(*) FROM ioc_sealevel_failed_dates "
+                f"WHERE station_code IN ({','.join(['?'] * len(codes))}) "
+                f"GROUP BY station_code",
+                list(codes),
+            )
+    except sqlite3.OperationalError as exc:
+        msg = str(exc)
+        if "no such table" in msg.lower():
+            logger.warning(
+                "sqlite has no ioc_sea_level / ioc_sealevel_failed_dates "
+                "(%s) — skipping sqlite phase. Pass --skip-sqlite to silence.",
+                msg,
+            )
+            return None
+        raise
     return {
         "data_per_station": [(r[0], r[1]) for r in rows],
         "failed_per_station": [(r[0], r[1]) for r in failed_rows],
@@ -144,22 +170,31 @@ async def _sqlite_inspect(codes: list[str], min_date: str | None,
 
 
 async def _sqlite_delete(codes: list[str], min_date: str | None,
-                         max_date: str | None) -> tuple[int, int]:
+                         max_date: str | None) -> tuple[int, int] | None:
+    """Delete contaminated rows from sqlite.
+
+    Returns None when neither table exists (host has no sqlite IOC mirror).
+    """
     where, params = _build_sqlite_where(codes, min_date, max_date)
-    async with safe_connect() as db:
-        # failed_dates first so a concurrent fetcher cannot re-issue the
-        # request between the two DELETEs.
-        cur1 = await db.execute(
-            f"DELETE FROM ioc_sealevel_failed_dates "
-            f"WHERE station_code IN ({','.join(['?'] * len(codes))})",
-            list(codes),
-        )
-        deleted_failed = cur1.rowcount
-        cur2 = await db.execute(
-            f"DELETE FROM ioc_sea_level WHERE {where}", params,
-        )
-        deleted_data = cur2.rowcount
-        await db.commit()
+    try:
+        async with safe_connect() as db:
+            # failed_dates first so a concurrent fetcher cannot re-issue the
+            # request between the two DELETEs.
+            cur1 = await db.execute(
+                f"DELETE FROM ioc_sealevel_failed_dates "
+                f"WHERE station_code IN ({','.join(['?'] * len(codes))})",
+                list(codes),
+            )
+            deleted_failed = cur1.rowcount
+            cur2 = await db.execute(
+                f"DELETE FROM ioc_sea_level WHERE {where}", params,
+            )
+            deleted_data = cur2.rowcount
+            await db.commit()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return None
+        raise
     return deleted_data, deleted_failed
 
 
@@ -200,35 +235,50 @@ async def _amain() -> int:
         logger.error("No station codes specified")
         return 2
 
+    if args.skip_sqlite and args.skip_bq:
+        logger.error("--skip-sqlite and --skip-bq together leave nothing to do.")
+        return 2
+
     logger.info(
         "Targeting station_codes=%s, min_date=%s, max_date=%s, "
-        "yes=%s, skip_bq=%s",
+        "yes=%s, skip_bq=%s, skip_sqlite=%s",
         codes, args.min_date, args.max_date, args.yes, args.skip_bq,
+        args.skip_sqlite,
     )
 
-    pre = await _sqlite_inspect(codes, args.min_date, args.max_date)
-    pre_data_total = sum(c for _, c in pre["data_per_station"])
-    pre_failed_total = sum(c for _, c in pre["failed_per_station"])
-    logger.info(
-        "[sqlite pre] ioc_sea_level rows targeted: %d (per-station: %s)",
-        pre_data_total, pre["data_per_station"],
-    )
-    logger.info(
-        "[sqlite pre] ioc_sealevel_failed_dates rows targeted: %d (per-station: %s)",
-        pre_failed_total, pre["failed_per_station"],
-    )
+    if args.skip_sqlite:
+        logger.info("[sqlite] skipped (--skip-sqlite)")
+    else:
+        pre = await _sqlite_inspect(codes, args.min_date, args.max_date)
+        if pre is None:
+            logger.info("[sqlite] tables absent — nothing to inspect or delete.")
+        else:
+            pre_data_total = sum(c for _, c in pre["data_per_station"])
+            pre_failed_total = sum(c for _, c in pre["failed_per_station"])
+            logger.info(
+                "[sqlite pre] ioc_sea_level rows targeted: %d (per-station: %s)",
+                pre_data_total, pre["data_per_station"],
+            )
+            logger.info(
+                "[sqlite pre] ioc_sealevel_failed_dates rows targeted: %d "
+                "(per-station: %s)",
+                pre_failed_total, pre["failed_per_station"],
+            )
 
     if not args.yes:
         logger.warning("DRY RUN — pass --yes to actually delete.")
         return 0
 
-    deleted_data, deleted_failed = await _sqlite_delete(
-        codes, args.min_date, args.max_date,
-    )
-    logger.info(
-        "[sqlite] deleted: %d data rows, %d failed_dates rows",
-        deleted_data, deleted_failed,
-    )
+    if not args.skip_sqlite:
+        result = await _sqlite_delete(codes, args.min_date, args.max_date)
+        if result is None:
+            logger.info("[sqlite] tables absent — DELETE skipped.")
+        else:
+            deleted_data, deleted_failed = result
+            logger.info(
+                "[sqlite] deleted: %d data rows, %d failed_dates rows",
+                deleted_data, deleted_failed,
+            )
 
     if not args.skip_bq:
         _bq_delete(codes, args.min_date, args.max_date)

--- a/scripts/smoke_test_phase_2_cleanup_dart.py
+++ b/scripts/smoke_test_phase_2_cleanup_dart.py
@@ -1,0 +1,134 @@
+"""Smoke test for Phase 2 (Stage 2.A follow-up) cleanup_ioc_sealevel_dart.
+
+Pure-unit, no network, no real sqlite/BigQuery. Verifies the BQ-only host
+support added on top of the original sqlite+BQ cleanup script:
+
+    - --skip-sqlite flag exists and is accepted by argparse
+    - --skip-sqlite + --skip-bq together exit 2 (nothing to do)
+    - _sqlite_inspect returns None on "no such table" OperationalError
+      (graceful fallback for hosts where IOC fetcher only writes to BQ)
+    - _sqlite_inspect re-raises any other OperationalError unchanged
+    - _sqlite_delete returns None on "no such table" OperationalError
+    - _amain with --skip-sqlite never calls the sqlite helpers and still
+      issues the BigQuery DELETE
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+import unittest
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _import_module():
+    import importlib
+
+    if "cleanup_ioc_sealevel_dart" in sys.modules:
+        return importlib.reload(sys.modules["cleanup_ioc_sealevel_dart"])
+    return importlib.import_module("cleanup_ioc_sealevel_dart")
+
+
+class TestArgparse(unittest.TestCase):
+    def test_skip_sqlite_flag_exists(self):
+        mod = _import_module()
+        with patch.object(sys, "argv", ["cleanup", "--skip-sqlite"]):
+            args = mod._parse_args()
+        self.assertTrue(args.skip_sqlite)
+        self.assertFalse(args.skip_bq)
+        self.assertFalse(args.yes)
+
+    def test_skip_bq_unchanged(self):
+        mod = _import_module()
+        with patch.object(sys, "argv", ["cleanup", "--skip-bq"]):
+            args = mod._parse_args()
+        self.assertTrue(args.skip_bq)
+        self.assertFalse(args.skip_sqlite)
+
+
+class TestSqliteGracefulFallback(unittest.IsolatedAsyncioTestCase):
+    async def test_inspect_returns_none_on_no_such_table(self):
+        mod = _import_module()
+
+        class _FakeDB:
+            async def execute_fetchall(self, *_a, **_kw):
+                raise sqlite3.OperationalError("no such table: ioc_sea_level")
+
+        @asynccontextmanager
+        async def _fake_connect():
+            yield _FakeDB()
+
+        with patch.object(mod, "safe_connect", _fake_connect):
+            result = await mod._sqlite_inspect(["dtok"], None, None)
+        self.assertIsNone(result)
+
+    async def test_inspect_reraises_other_operational_error(self):
+        mod = _import_module()
+
+        class _FakeDB:
+            async def execute_fetchall(self, *_a, **_kw):
+                raise sqlite3.OperationalError("database is locked")
+
+        @asynccontextmanager
+        async def _fake_connect():
+            yield _FakeDB()
+
+        with patch.object(mod, "safe_connect", _fake_connect):
+            with self.assertRaises(sqlite3.OperationalError):
+                await mod._sqlite_inspect(["dtok"], None, None)
+
+    async def test_delete_returns_none_on_no_such_table(self):
+        mod = _import_module()
+
+        class _FakeDB:
+            async def execute(self, *_a, **_kw):
+                raise sqlite3.OperationalError(
+                    "no such table: ioc_sealevel_failed_dates"
+                )
+
+            async def commit(self):
+                pass
+
+        @asynccontextmanager
+        async def _fake_connect():
+            yield _FakeDB()
+
+        with patch.object(mod, "safe_connect", _fake_connect):
+            result = await mod._sqlite_delete(["dtok"], None, None)
+        self.assertIsNone(result)
+
+
+class TestAmainSkipFlags(unittest.IsolatedAsyncioTestCase):
+    async def test_skip_sqlite_and_skip_bq_together_exit_2(self):
+        mod = _import_module()
+        argv = ["cleanup", "--skip-sqlite", "--skip-bq", "--yes"]
+        with patch.object(sys, "argv", argv):
+            rc = await mod._amain()
+        self.assertEqual(rc, 2)
+
+    async def test_skip_sqlite_bypasses_sqlite_helpers_and_runs_bq(self):
+        mod = _import_module()
+        argv = ["cleanup", "--skip-sqlite", "--yes",
+                "--station-codes", "dtok,dtok2"]
+        sqlite_inspect = AsyncMock()
+        sqlite_delete = AsyncMock()
+        bq_delete = MagicMock(return_value=0)
+        with patch.object(sys, "argv", argv), \
+             patch.object(mod, "_sqlite_inspect", sqlite_inspect), \
+             patch.object(mod, "_sqlite_delete", sqlite_delete), \
+             patch.object(mod, "_bq_delete", bq_delete):
+            rc = await mod._amain()
+        self.assertEqual(rc, 0)
+        sqlite_inspect.assert_not_called()
+        sqlite_delete.assert_not_called()
+        bq_delete.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Stage 2.A の `cleanup_ioc_sealevel_dart.py` (PR #119) を RPi5 で実行しようとしたら `sqlite3.OperationalError: no such table: ioc_sea_level` で blocked。RPi5 sqlite には IOC テーブル自体が無く (10 テーブルのみ)、IOC fetcher は GHA runner 上で動いて BQ に直接書き込んでいる構成のため。

BQ には DART contamination 6 stations / 15,933 rows 実在を確認済 (`dtok` 4117, `dtok2` 3314, `dryu` 3393, `dryu2` 3381, `dsen` 864, `drus` 864)。

このため cleanup script を **BQ-only 実行可能** にする最小変更を入れる:

- `--skip-sqlite` フラグ追加 (`--skip-bq` と対称)
- `--skip-sqlite + --skip-bq` 同時指定で exit 2 (nothing to do)
- `_sqlite_inspect` / `_sqlite_delete` で IOC 関連テーブルが無いとき (`OperationalError: no such table`) graceful skip + warning。case-insensitive で判定 (`scripts/fetch_cloud_fraction.py:82` 既存 precedent と統一)
- それ以外の `OperationalError` (例: database is locked) は re-raise unchanged
- `_amain` で `--skip-sqlite` 時は sqlite helper を一切呼ばない

## Test plan

- [x] `python scripts/smoke_test_phase_2_cleanup_dart.py` → 7/7 pass (argparse / graceful fallback / mutex / skip-sqlite path)
- [x] Opus subagent レビュー: Approve (case-sensitivity nit 反映済)
- [ ] Merge 後 RPi5 で `git pull && GEOHAZARD_DB_PATH=... python3 scripts/cleanup_ioc_sealevel_dart.py --skip-sqlite` (dry-run) → `--skip-sqlite --yes` で BQ DELETE 実行
- [ ] BQ で `SELECT station_code, COUNT(*) FROM \`data-platform-490901.geohazard.ioc_sea_level\` WHERE station_code IN ('dtok','dtok2','dryu','dryu2','dsen','drus') GROUP BY station_code` が 0 行確認

## 既存 sqlite + BQ ローカル機への影響

`--skip-sqlite` を付けない既存 flow は完全保持。graceful fallback は「テーブルが本当に無い時のみ None を返す」ので、テーブルが有る環境では従来通り inspect → DELETE が走る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--skip-sqlite` CLI option to support SQLite-only or BigQuery-only cleanup workflows.
  * Enhanced validation to prevent conflicting skip flags.

* **Improvements**
  * Improved resilience with graceful handling of missing database tables during cleanup operations.

* **Tests**
  * Added comprehensive test coverage for CLI argument parsing and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->