### PR TITLE
fix(merge): bump timeout 60->150 + remove redundant Snapshot integrity_check/backup

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2023,7 +2023,11 @@ jobs:
     needs: [fetch-modis, fetch-so2, fetch-cloud, fetch-snet, fetch-hinet, light]
     if: always() && inputs.target != 'diagnostic'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Bumped 60->150 after Hi-net Stage 1 (PR #127) pushed merge time past
+    # 60min ceiling (run 25276071313 / 25279499629 both cancelled at Snapshot
+    # step). 150min matches fetch-snet/fetch-hinet/light heavy-job tier with
+    # comfortable headroom for 25min BQ upload + 10min merge + ~5min misc.
+    timeout-minutes: 150
 
     steps:
       - uses: actions/checkout@v4
@@ -2104,29 +2108,32 @@ jobs:
       - name: Snapshot merged DB for checkpoint
         id: snapshot
         if: steps.merge.outcome == 'success'
+        # Was: wal_checkpoint + integrity_check + src.backup() (full 2GB DB
+        # copy + page-by-page integrity scan). Removed integrity_check and
+        # src.backup() because:
+        #   - integrity_check is already run by merge_checkpoints.py:_verify()
+        #     before the merge step exits with success, on the same dst file.
+        #   - src.backup() was a 2GB file rewrite intended for compaction +
+        #     WAL flush, but compaction is not required by downstream steps
+        #     (load_raw_to_bq.py reads SQLite -> Pandas -> BQ regardless of
+        #     page fragmentation). Only the WAL flush is needed so that
+        #     Coverage report and Upload checkpoint artifact see committed
+        #     pages.
+        # Combined snapshot step time: ~10min -> ~5sec (run 25276071313 /
+        # 25279499629 exceeded 60min timeout after Hi-net data added; Snapshot is the dominant suspect, blocking
+        # all subsequent BQ uploads).
         run: |
           python3 -c "
           import sqlite3, sys
           try:
-              src = sqlite3.connect('data/geohazard.db')
-              src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
-              r = src.execute('PRAGMA integrity_check').fetchone()[0]
-              if r != 'ok':
-                  print(f'REFUSING to snapshot corrupt DB: {r[:200]}')
-                  src.close()
-                  sys.exit(1)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
-              src.backup(dst)
-              dst.close()
-              src.close()
-              print('Snapshot created (post-integrity-check)')
+              conn = sqlite3.connect('data/geohazard.db')
+              conn.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+              conn.close()
+              print('WAL checkpoint flushed (integrity already verified by merge_checkpoints.py:_verify)')
           except Exception as e:
-              print(f'Snapshot failed: {e}')
+              print(f'wal_checkpoint failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
-          fi
 
       - name: Coverage report
         if: steps.snapshot.outcome == 'success'


### PR DESCRIPTION
## Summary

Two consecutive Backfill Data runs hit timeout in merge job after Hi-net Stage 1 (PR #127), blocking BigQuery upload:
- run [25276071313](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25276071313) — failure (job 30min, prior `timeout-minutes: 30`)
- run [25279499629](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25279499629) — cancelled (job 65min, hit current 60min ceiling)

Both failed at Snapshot step (step 12). All fetch jobs (snet/hinet/light/etc.) succeeded. snet BigQuery `distinct_days` stuck at 1927 since the last successful run.

## Root cause

| Item | Value |
|---|---|
| Last success run [74109114261](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25273483691) merge job total | **58 min** (1 min under 60 ceiling) |
| Last success Snapshot step | 10 min 21 sec |
| Failed run snapshot step | 30+ min (cancelled at job timeout) |
| Hi-net contribution | +1 artifact download (~1 min) +1 overlay copy in merge_checkpoints.py (~9 min) |

Snapshot step body was:
```python
src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
r = src.execute('PRAGMA integrity_check').fetchone()[0]   # full DB scan
src.backup(dst)                                            # 2GB full DB copy
# then: mv geohazard_snapshot.db -> geohazard.db
```

`scripts/merge_checkpoints.py:_verify()` (called inside `merge()` before successful exit, wired to `sys.exit(0/1)` in `__main__`) **already runs `PRAGMA integrity_check`** on the same `dst` file. The Snapshot step's integrity_check was completely redundant.

`src.backup(dst)` was a 2GB rewrite for compaction + WAL flush, but downstream consumers (`load_raw_to_bq.py`, `Upload checkpoint artifact`) don't need compaction — they read SQLite -> Pandas -> BQ regardless of page fragmentation. Only WAL flush matters, and `wal_checkpoint(TRUNCATE)` alone provides it.

## Changes

1. **`timeout-minutes: 60 -> 150`**
   Aligns merge with the heavy-job tier (fetch-snet/fetch-hinet 240, light 200). 150 < 180 (cron period) avoids overlap with `concurrency: cancel-in-progress: false` queueing.

2. **Snapshot step simplified to `PRAGMA wal_checkpoint(TRUNCATE)` only**
   - Dropped: `PRAGMA integrity_check` (redundant with merge_checkpoints.py)
   - Dropped: `src.backup(dst)` + `mv geohazard_snapshot.db geohazard.db` (compaction not required by downstream steps)

## Expected impact

- Snapshot step: ~10 min -> ~5 sec (eliminates the dominant suspect)
- Merge job total: ~58 min -> ~48 min on next successful run
- 150 min ceiling provides headroom for future data growth without immediate optimization of merge step or BQ upload (planned as separate PRs).

## Out of scope (planned follow-up PRs)

- **Fetch artifact size**: Each ~2GB because every fetch job emits "prior checkpoint + own overlay" full snapshot. Could be reduced to overlay-only (~tens of MB).
- **BQ upload (25 min)**: Currently `WRITE_TRUNCATE` all 31 tables. Incremental upload would be much faster but requires careful design (see lightning_thunder_hour 31,824 -> 24,480 incident on 2026-04-17).

## Review

Reviewed by Opus subagent: APPROVE, no MUST-FIX. SHOULD-FIX 1 (soften "30+ min hang" wording to "exceeded 60min timeout") applied. `merge_checkpoints.py:__main__` wiring (`sys.exit(0 if merge() else 1)`) verified.

## Test plan

- [ ] CI green on this branch
- [ ] After merge, observe next Backfill Data cron run completes merge job in <60min
- [ ] BigQuery `snet_waveform.distinct_days` advances past 1927 in subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased merge operation timeout from 60 to 150 minutes to support longer-running merge operations
  * Optimized database checkpoint process to streamline post-merge cleanup steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->