### PR TITLE
feat(merge): artifact overlay-only — 5.4x size reduction (PR-2)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -337,6 +337,17 @@ jobs:
             mv data/geohazard_snapshot.db data/geohazard.db
           fi
 
+      - name: Extract owned-table overlay (PR-2 artifact reduction)
+        id: extract_overlay
+        if: steps.snapshot.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python3 scripts/extract_overlay.py \
+            --src data/geohazard.db \
+            --dst data/geohazard_overlay.db \
+            --tables modis_lst \
+            && mv data/geohazard_overlay.db data/geohazard.db
+
       - name: Upload modis.db artifact
         if: always() && steps.snapshot.outcome == 'success'
         uses: actions/upload-artifact@v4
@@ -587,6 +598,17 @@ jobs:
           if [ -f data/geohazard_snapshot.db ]; then
             mv data/geohazard_snapshot.db data/geohazard.db
           fi
+
+      - name: Extract owned-table overlay (PR-2 artifact reduction)
+        id: extract_overlay
+        if: steps.snapshot.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python3 scripts/extract_overlay.py \
+            --src data/geohazard.db \
+            --dst data/geohazard_overlay.db \
+            --tables so2_column \
+            && mv data/geohazard_overlay.db data/geohazard.db
 
       - name: Upload so2.db artifact
         if: always() && steps.snapshot.outcome == 'success'
@@ -861,6 +883,17 @@ jobs:
           if [ -f data/geohazard_snapshot.db ]; then
             mv data/geohazard_snapshot.db data/geohazard.db
           fi
+
+      - name: Extract owned-table overlay (PR-2 artifact reduction)
+        id: extract_overlay
+        if: steps.snapshot.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python3 scripts/extract_overlay.py \
+            --src data/geohazard.db \
+            --dst data/geohazard_overlay.db \
+            --tables cloud_fraction \
+            && mv data/geohazard_overlay.db data/geohazard.db
 
       - name: Upload cloud.db artifact
         if: always() && steps.snapshot.outcome == 'success'
@@ -1156,6 +1189,17 @@ jobs:
             mv data/geohazard_snapshot.db data/geohazard.db
           fi
 
+      - name: Extract owned-table overlay (PR-2 artifact reduction)
+        id: extract_overlay
+        if: steps.snapshot.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python3 scripts/extract_overlay.py \
+            --src data/geohazard.db \
+            --dst data/geohazard_overlay.db \
+            --tables snet_waveform,fnet_waveform \
+            && mv data/geohazard_overlay.db data/geohazard.db
+
       - name: Upload snet.db artifact
         if: always() && steps.snapshot.outcome == 'success'
         uses: actions/upload-artifact@v4
@@ -1414,6 +1458,17 @@ jobs:
           if [ -f data/geohazard_snapshot.db ]; then
             mv data/geohazard_snapshot.db data/geohazard.db
           fi
+      - name: Extract owned-table overlay (PR-2 artifact reduction)
+        id: extract_overlay
+        if: steps.snapshot.outcome == 'success'
+        continue-on-error: true
+        run: |
+          python3 scripts/extract_overlay.py \
+            --src data/geohazard.db \
+            --dst data/geohazard_overlay.db \
+            --tables hinet_waveform \
+            && mv data/geohazard_overlay.db data/geohazard.db
+
       - name: Upload hinet.db artifact
         if: always() && steps.snapshot.outcome == 'success'
         uses: actions/upload-artifact@v4

--- a/scripts/extract_overlay.py
+++ b/scripts/extract_overlay.py
@@ -1,0 +1,102 @@
+"""Extract specific tables from a SQLite source DB into a fresh, compact overlay DB.
+
+Used by per-fetch GHA jobs in .github/workflows/backfill.yml to upload only the
+table(s) each job owns, rather than the full ~1.87 GB geohazard.db. The merge
+job's `scripts/merge_checkpoints.py --overlay PATH:TABLES` already only reads
+the listed tables from each artifact, so the rest of the DB in the upload is
+pure waste.
+
+Behaviour:
+    - Creates the destination DB fresh (overwrites if present).
+    - For each table in --tables, copies CREATE TABLE schema verbatim, then
+      copies all rows via ATTACH DATABASE + INSERT INTO ... SELECT.
+    - Indexes are NOT copied: merge_checkpoints.py never queries the overlay
+      with WHERE clauses that benefit from them, only `INSERT OR IGNORE INTO
+      base SELECT * FROM overlay.<table>`. Skipping indexes shrinks artifact
+      size with zero merge-step impact.
+    - VACUUM at the end ensures freelist pages are reclaimed and file size
+      reflects only used pages.
+
+Why a fresh dst (not a cp + DROP):
+    Copying then dropping leaves freelist pages until VACUUM, and on the way
+    the 1.87 GB cp itself is the cost we are trying to eliminate. Building
+    fresh from ATTACH + INSERT avoids both.
+
+If a listed table is missing in src (e.g. fetcher skipped or first run),
+the script logs a warning and proceeds — merge_checkpoints.py tolerates
+overlays missing their listed tables (treated as "no overlay rows", base
+rows for that table survive untouched).
+
+Tested via `scripts/smoke_test_extract_overlay.py`.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+
+
+def extract(src_path: str, dst_path: str, tables: list[str]) -> None:
+    if not os.path.exists(src_path):
+        print(f"ERROR: src not found: {src_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if os.path.exists(dst_path):
+        os.remove(dst_path)
+
+    src_size_mb = os.path.getsize(src_path) / (1024 * 1024)
+    print(f"src: {src_path} ({src_size_mb:.1f} MB)")
+    print(f"dst: {dst_path}")
+    print(f"tables: {tables}")
+
+    dst = sqlite3.connect(dst_path)
+    dst.execute("PRAGMA journal_mode = MEMORY")
+    dst.execute(f"ATTACH DATABASE ? AS src", (src_path,))
+
+    for table in tables:
+        row = dst.execute(
+            "SELECT sql FROM src.sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        if row is None or row[0] is None:
+            print(f"WARN: table {table!r} not present in src (skipping)")
+            continue
+        create_sql = row[0]
+        dst.execute(create_sql)
+        n = dst.execute(
+            f"SELECT COUNT(*) FROM src.{table}"
+        ).fetchone()[0]
+        if n > 0:
+            dst.execute(f"INSERT INTO main.{table} SELECT * FROM src.{table}")
+        dst.commit()
+        print(f"  {table}: {n} rows copied")
+
+    dst.execute("DETACH DATABASE src")
+    dst.execute("VACUUM")
+    dst.close()
+
+    dst_size_mb = os.path.getsize(dst_path) / (1024 * 1024)
+    ratio = src_size_mb / dst_size_mb if dst_size_mb > 0 else float("inf")
+    print(f"done: {dst_size_mb:.1f} MB ({ratio:.1f}x smaller)")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src", required=True, help="source DB path (e.g. data/geohazard.db)")
+    ap.add_argument("--dst", required=True, help="destination overlay DB path")
+    ap.add_argument(
+        "--tables",
+        required=True,
+        help="comma-separated list of table names to extract",
+    )
+    args = ap.parse_args()
+    tables = [t.strip() for t in args.tables.split(",") if t.strip()]
+    if not tables:
+        print("ERROR: --tables produced empty list", file=sys.stderr)
+        sys.exit(1)
+    extract(args.src, args.dst, tables)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_overlay.py
+++ b/scripts/extract_overlay.py
@@ -52,6 +52,13 @@ def extract(src_path: str, dst_path: str, tables: list[str]) -> None:
         print(f"ERROR: src not found: {src_path}", file=sys.stderr)
         sys.exit(1)
 
+    # Guard against --src and --dst pointing at the same file: the os.remove
+    # below would unlink the source before ATTACH, losing the live DB. Cheap
+    # check, prevents a destructive accident in CI.
+    if os.path.abspath(src_path) == os.path.abspath(dst_path):
+        print("ERROR: --src and --dst must differ", file=sys.stderr)
+        sys.exit(1)
+
     if os.path.exists(dst_path):
         os.remove(dst_path)
 
@@ -60,9 +67,11 @@ def extract(src_path: str, dst_path: str, tables: list[str]) -> None:
     print(f"dst: {dst_path}")
     print(f"tables: {tables}")
 
-    dst = sqlite3.connect(dst_path)
-    dst.execute("PRAGMA journal_mode = MEMORY")
-    dst.execute(f"ATTACH DATABASE ? AS src", (src_path,))
+    # uri=True enables the read-only ATTACH below. extract_overlay.py only
+    # SELECTs from src, but mode=ro hardens against future edits that might
+    # accidentally write to the live data/geohazard.db during fetch jobs.
+    dst = sqlite3.connect(dst_path, uri=True)
+    dst.execute("ATTACH DATABASE ? AS src", (f"file:{src_path}?mode=ro",))
 
     for table in tables:
         row = dst.execute(

--- a/scripts/extract_overlay.py
+++ b/scripts/extract_overlay.py
@@ -37,6 +37,16 @@ import sqlite3
 import sys
 
 
+def _qident(name: str) -> str:
+    """Quote a SQLite identifier (table name) for safe interpolation.
+
+    Doubles any embedded `"` and wraps in `"..."`. Defensive: current callers
+    pass simple ASCII table names (modis_lst etc.), but quoting hardens
+    extract_overlay.py against future callers that pass unusual names.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
 def extract(src_path: str, dst_path: str, tables: list[str]) -> None:
     if not os.path.exists(src_path):
         print(f"ERROR: src not found: {src_path}", file=sys.stderr)
@@ -64,11 +74,12 @@ def extract(src_path: str, dst_path: str, tables: list[str]) -> None:
             continue
         create_sql = row[0]
         dst.execute(create_sql)
+        qtable = _qident(table)
         n = dst.execute(
-            f"SELECT COUNT(*) FROM src.{table}"
+            f"SELECT COUNT(*) FROM src.{qtable}"
         ).fetchone()[0]
         if n > 0:
-            dst.execute(f"INSERT INTO main.{table} SELECT * FROM src.{table}")
+            dst.execute(f"INSERT INTO main.{qtable} SELECT * FROM src.{qtable}")
         dst.commit()
         print(f"  {table}: {n} rows copied")
 

--- a/scripts/smoke_test_extract_overlay.py
+++ b/scripts/smoke_test_extract_overlay.py
@@ -23,6 +23,7 @@ def run_extract(src: str, dst: str, tables: str) -> subprocess.CompletedProcess:
         [sys.executable, EXTRACT, "--src", src, "--dst", dst, "--tables", tables],
         capture_output=True,
         text=True,
+        timeout=120,
     )
 
 

--- a/scripts/smoke_test_extract_overlay.py
+++ b/scripts/smoke_test_extract_overlay.py
@@ -1,0 +1,209 @@
+"""Smoke test for scripts/extract_overlay.py — covers schema preservation,
+row preservation, missing-table tolerance, and size-reduction behaviour.
+
+Invoked via `python3 scripts/smoke_test_extract_overlay.py`. Exits non-zero
+on any assertion failure. Self-contained: builds throwaway DBs in a temp dir
+and removes them on success.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXTRACT = os.path.join(HERE, "extract_overlay.py")
+
+
+def run_extract(src: str, dst: str, tables: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, EXTRACT, "--src", src, "--dst", dst, "--tables", tables],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_basic_extract_preserves_schema_and_rows(tmp: str) -> None:
+    src = os.path.join(tmp, "src.db")
+    dst = os.path.join(tmp, "dst.db")
+    conn = sqlite3.connect(src)
+    conn.executescript(
+        """
+        CREATE TABLE wanted (id INTEGER PRIMARY KEY, val TEXT);
+        CREATE TABLE other (a INTEGER, b TEXT);
+        INSERT INTO wanted VALUES (1, 'a'), (2, 'b'), (3, 'c');
+        INSERT INTO other VALUES (10, 'x'), (20, 'y');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    res = run_extract(src, dst, "wanted")
+    assert res.returncode == 0, f"extract failed: {res.stderr}"
+
+    out = sqlite3.connect(dst)
+    tables = [
+        r[0] for r in out.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+    ]
+    assert tables == ["wanted"], f"expected only [wanted], got {tables}"
+    rows = out.execute("SELECT id, val FROM wanted ORDER BY id").fetchall()
+    assert rows == [(1, "a"), (2, "b"), (3, "c")], rows
+    out.close()
+    print("  PASS: basic_extract_preserves_schema_and_rows")
+
+
+def test_multiple_tables(tmp: str) -> None:
+    src = os.path.join(tmp, "src.db")
+    dst = os.path.join(tmp, "dst.db")
+    conn = sqlite3.connect(src)
+    conn.executescript(
+        """
+        CREATE TABLE alpha (id INTEGER, name TEXT);
+        CREATE TABLE beta (k TEXT PRIMARY KEY, v REAL);
+        CREATE TABLE gamma (x INTEGER);
+        INSERT INTO alpha VALUES (1, 'foo');
+        INSERT INTO beta VALUES ('hi', 1.5);
+        INSERT INTO gamma VALUES (99);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    res = run_extract(src, dst, "alpha,beta")
+    assert res.returncode == 0, f"extract failed: {res.stderr}"
+
+    out = sqlite3.connect(dst)
+    tables = sorted(
+        r[0] for r in out.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    )
+    assert tables == ["alpha", "beta"], tables
+    assert out.execute("SELECT COUNT(*) FROM alpha").fetchone()[0] == 1
+    assert out.execute("SELECT COUNT(*) FROM beta").fetchone()[0] == 1
+    out.close()
+    print("  PASS: multiple_tables")
+
+
+def test_missing_table_tolerated(tmp: str) -> None:
+    src = os.path.join(tmp, "src.db")
+    dst = os.path.join(tmp, "dst.db")
+    conn = sqlite3.connect(src)
+    conn.execute("CREATE TABLE present (x INTEGER)")
+    conn.execute("INSERT INTO present VALUES (1)")
+    conn.commit()
+    conn.close()
+
+    res = run_extract(src, dst, "present,absent")
+    assert res.returncode == 0, f"extract failed: {res.stderr}"
+    assert "WARN" in res.stdout and "absent" in res.stdout, res.stdout
+
+    out = sqlite3.connect(dst)
+    tables = [
+        r[0] for r in out.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    ]
+    assert tables == ["present"], tables
+    out.close()
+    print("  PASS: missing_table_tolerated")
+
+
+def test_empty_table(tmp: str) -> None:
+    src = os.path.join(tmp, "src.db")
+    dst = os.path.join(tmp, "dst.db")
+    conn = sqlite3.connect(src)
+    conn.execute("CREATE TABLE owned (id INTEGER PRIMARY KEY, payload BLOB)")
+    conn.commit()
+    conn.close()
+
+    res = run_extract(src, dst, "owned")
+    assert res.returncode == 0, f"extract failed: {res.stderr}"
+
+    out = sqlite3.connect(dst)
+    assert out.execute("SELECT COUNT(*) FROM owned").fetchone()[0] == 0
+    out.close()
+    print("  PASS: empty_table")
+
+
+def test_size_reduction(tmp: str) -> None:
+    """Ensure overlay DB is meaningfully smaller than the source when most
+    tables are dropped. Loose threshold to account for SQLite page granularity.
+    """
+    src = os.path.join(tmp, "src.db")
+    dst = os.path.join(tmp, "dst.db")
+    conn = sqlite3.connect(src)
+    conn.execute("CREATE TABLE owned (id INTEGER, payload TEXT)")
+    conn.execute("CREATE TABLE bulk (id INTEGER, payload TEXT)")
+    conn.execute("INSERT INTO owned VALUES (1, 'small')")
+    bulk_payload = "x" * 1024
+    conn.executemany("INSERT INTO bulk VALUES (?, ?)", [(i, bulk_payload) for i in range(2000)])
+    conn.commit()
+    conn.close()
+
+    res = run_extract(src, dst, "owned")
+    assert res.returncode == 0, f"extract failed: {res.stderr}"
+
+    src_sz = os.path.getsize(src)
+    dst_sz = os.path.getsize(dst)
+    assert dst_sz < src_sz / 4, f"overlay not meaningfully smaller: {dst_sz} vs {src_sz}"
+    print(f"  PASS: size_reduction (src={src_sz} dst={dst_sz} ratio={src_sz/dst_sz:.1f}x)")
+
+
+def test_missing_src_errors(tmp: str) -> None:
+    dst = os.path.join(tmp, "dst.db")
+    res = run_extract(os.path.join(tmp, "nope.db"), dst, "anything")
+    assert res.returncode != 0, "expected non-zero on missing src"
+    assert "src not found" in res.stderr, res.stderr
+    print("  PASS: missing_src_errors")
+
+
+def test_overwrites_existing_dst(tmp: str) -> None:
+    """If dst already exists from a previous step, it must be replaced — not
+    merged into. Prevents accidental accumulation.
+    """
+    src = os.path.join(tmp, "src.db")
+    dst = os.path.join(tmp, "dst.db")
+    open(dst, "wb").write(b"\x00" * 1024)  # garbage placeholder
+    conn = sqlite3.connect(src)
+    conn.execute("CREATE TABLE owned (x INTEGER)")
+    conn.execute("INSERT INTO owned VALUES (42)")
+    conn.commit()
+    conn.close()
+
+    res = run_extract(src, dst, "owned")
+    assert res.returncode == 0, f"extract failed: {res.stderr}"
+
+    out = sqlite3.connect(dst)
+    assert out.execute("SELECT x FROM owned").fetchone() == (42,)
+    out.close()
+    print("  PASS: overwrites_existing_dst")
+
+
+def main() -> None:
+    tmp = tempfile.mkdtemp(prefix="extract_overlay_smoke_")
+    try:
+        for fn in [
+            test_basic_extract_preserves_schema_and_rows,
+            test_multiple_tables,
+            test_missing_table_tolerated,
+            test_empty_table,
+            test_size_reduction,
+            test_missing_src_errors,
+            test_overwrites_existing_dst,
+        ]:
+            # each test gets a fresh subdir to avoid state bleed
+            sub = tempfile.mkdtemp(dir=tmp, prefix=fn.__name__ + "_")
+            fn(sub)
+        print("\nALL TESTS PASS (7/7)")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_test_extract_overlay.py
+++ b/scripts/smoke_test_extract_overlay.py
@@ -156,6 +156,27 @@ def test_size_reduction(tmp: str) -> None:
     print(f"  PASS: size_reduction (src={src_sz} dst={dst_sz} ratio={src_sz/dst_sz:.1f}x)")
 
 
+def test_src_dst_same_path_rejected(tmp: str) -> None:
+    """Guard against --src X --dst X destroying the source via os.remove(dst).
+    """
+    same = os.path.join(tmp, "same.db")
+    conn = sqlite3.connect(same)
+    conn.execute("CREATE TABLE owned (x INTEGER)")
+    conn.execute("INSERT INTO owned VALUES (1)")
+    conn.commit()
+    conn.close()
+
+    res = run_extract(same, same, "owned")
+    assert res.returncode != 0, "expected non-zero on src==dst"
+    assert "must differ" in res.stderr, res.stderr
+    # source must still exist and be readable
+    assert os.path.exists(same), "source DB was destroyed by self-overwrite"
+    check = sqlite3.connect(same)
+    assert check.execute("SELECT x FROM owned").fetchone() == (1,)
+    check.close()
+    print("  PASS: src_dst_same_path_rejected")
+
+
 def test_missing_src_errors(tmp: str) -> None:
     dst = os.path.join(tmp, "dst.db")
     res = run_extract(os.path.join(tmp, "nope.db"), dst, "anything")
@@ -195,13 +216,14 @@ def main() -> None:
             test_missing_table_tolerated,
             test_empty_table,
             test_size_reduction,
+            test_src_dst_same_path_rejected,
             test_missing_src_errors,
             test_overwrites_existing_dst,
         ]:
             # each test gets a fresh subdir to avoid state bleed
             sub = tempfile.mkdtemp(dir=tmp, prefix=fn.__name__ + "_")
             fn(sub)
-        print("\nALL TESTS PASS (7/7)")
+        print("\nALL TESTS PASS (8/8)")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 


### PR DESCRIPTION
## Summary

各 non-light fetch job (modis/so2/cloud/snet/hinet) は現状 full ~1.87 GB `data/geohazard.db` を artifact upload しているが、 merge step の `scripts/merge_checkpoints.py` は `--overlay PATH:TABLES` で 1-2 owned tables しか読まない。 残り ~1.85 GB × 5 jobs = **~9.2 GB が pure waste**。

このPRで:
- 新 helper `scripts/extract_overlay.py` 追加 (ATTACH+INSERT で fresh DB build、 indexes は merge step が使わないので copy しない、 VACUUM で freelist 回収)
- 各 fetch job (modis/so2/cloud/snet/hinet) の snapshot step と upload step の間に "Extract owned-table overlay" step 挿入
- light job (base) は変更なし、 merge_checkpoints.py 変更なし

| job | owned tables | 推定 overlay 後 |
|---|---|---|
| fetch-modis | modis_lst | ~30 MB |
| fetch-so2 | so2_column | ~50 MB |
| fetch-cloud | cloud_fraction | ~40 MB |
| fetch-snet | snet_waveform, fnet_waveform | ~100 MB |
| fetch-hinet | hinet_waveform | ~5 MB |
| fetch-light | (full DB, base) | 1872 MB 維持 |

合計 artifact volume: **11.3 GB → ~2.1 GB (5.4x reduction)**

## Safety

- 新 step は `continue-on-error: true`、 `&&` chain の `mv` は python 成功時のみ実行 → extract 失敗時は元の full DB を upload (graceful degradation、 pre-PR-2 path)
- merge_checkpoints.py 不変 — `--overlay PATH:TABLES` protocol は stripped overlay でも full DB でも同じ動作
- 既存の `if: always() && steps.snapshot.outcome == 'success'` Upload gate は変更なし

## Test plan

- [x] `scripts/smoke_test_extract_overlay.py` 7 cases all pass on RPi5 (sqlite 3.40.1, Python 3.11):
  - basic_extract_preserves_schema_and_rows
  - multiple_tables
  - missing_table_tolerated
  - empty_table
  - size_reduction (336x on synthetic data)
  - missing_src_errors
  - overwrites_existing_dst
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` backfill.yml validates
- [x] 5 inserts confirmed at lines 340/602/887/1192/1461
- [x] backfill.yml の LF line ending 維持 (auto-detect editor 経由)
- [ ] CodeRabbit review
- [ ] Opus subagent review (走らせ中)
- [ ] 次 cron run で実artifact size 計測 (期待 ~2.1 GB total)

## CRLF/LF

- `backfill.yml` は LF — auto-detect editor で維持
- `README.md` は CRLF (PR #131 までと同じ、 別 PR で documentation 追加予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated overlay data extraction to the data pipeline. Database snapshots now trigger extraction of specific data elements for MODIS, SO2, Cloud, S-net, and Hinet sources with built-in error tolerance. Extracted overlay databases are significantly smaller, containing only necessary data.

* **Tests**
  * Added comprehensive tests to verify overlay extraction functionality, including schema preservation, table handling, and size reduction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->