### PR TITLE
feat(cosmic_ray): expand NMDB stations 3 → 9 for global summed-rate density

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1789,7 +1789,7 @@ jobs:
         id: fetch_cosmic_ray
         if: inputs.target == 'all' || inputs.target == 'cosmic_ray' || inputs.target == ''
         continue-on-error: true
-        timeout-minutes: 20
+        timeout-minutes: 35
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |

--- a/DATA_LICENSES.md
+++ b/DATA_LICENSES.md
@@ -80,9 +80,15 @@ European Union's FP7 programme (contract no. 213007) for providing data.
 ```
 
 ### Per-station (used in this project)
-- **IRKT** (Irkutsk): Check www.nmdb.eu/station/IRKT
-- **OULU** (Oulu): Check www.nmdb.eu/station/OULU
-- **PSNM** (Doi Inthanon): Check www.nmdb.eu/station/PSNM
+- **IRKT** (Irkutsk, Russia, 3.64 GV): Check www.nmdb.eu/station/IRKT
+- **OULU** (Oulu, Finland, 0.81 GV): Check www.nmdb.eu/station/OULU
+- **PSNM** (Doi Inthanon, Thailand, 16.80 GV): Check www.nmdb.eu/station/PSNM
+- **APTY** (Apatity, Russia, 0.65 GV): Check www.nmdb.eu/station/APTY
+- **JUNG** (Jungfraujoch, Switzerland, 4.49 GV): Check www.nmdb.eu/station/JUNG
+- **ATHN** (Athens, Greece, 8.53 GV): Check www.nmdb.eu/station/ATHN
+- **ROME** (Rome, Italy, 6.27 GV): Check www.nmdb.eu/station/ROME
+- **BKSN** (Baksan, Russia/Caucasus, 5.70 GV): Check www.nmdb.eu/station/BKSN
+- **AATB** (Alma-Ata B, Kazakhstan, 5.90 GV): Check www.nmdb.eu/station/AATB
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -738,7 +738,7 @@ gh workflow run "Earthquake Correlation Analysis" \
 | `fetch_gnss_tec.py` | Nagoya Univ. ISEE (AGRID2/GRID2 netCDF) | GNSS-TEC 0.5° grid, 1h temporal, 5.3M records (no auth, 2 hrs/day × 200 dates/run) |
 | `fetch_modis_lst.py` | ORNL DAAC TESViS API | MODIS LST 1km: M5.5+ land epicenters ±14d + random control (rate limited) |
 | `fetch_kakioka_ulf.py` | INTERMAGNET BGS GIN + WDC Kyoto | KAK/MMB/KNY 1-min geomagnetic: M6+ events ±7d (IAGA-2002 format) |
-| `fetch_nmdb_cosmicray.py` | NMDB (Neutron Monitor Database) | Daily cosmic ray count rates: IRKT/OULU/PSNM, 2011-present (no auth) |
+| `fetch_nmdb_cosmicray.py` | NMDB (Neutron Monitor Database) | Daily cosmic ray count rates: 9 stations (IRKT/OULU/PSNM/APTY/JUNG/ATHN/ROME/BKSN/AATB), 2011-present (no auth) |
 | `fetch_cses_satellite.py` | INTERMAGNET BGS GIN + CSES-Limadou | KAK/MMB/KNY 1-min geomag → hourly downsample (2011-2026, 7-day batch) + CSES satellite EM (2018+, auth required) |
 | `fetch_blitzortung.py` | Blitzortung.org + Univ. Bonn sferics | Lightning stroke counts aggregated to 2° grid cells (Japan region, `lightning` table) |
 | `fetch_iss_lis_lightning.py` | NASA GHRC DAAC (Earthdata auth) | ISS LIS flash counts 2017-2023, 2° cells (`iss_lis_lightning` table, separate from Blitzortung) |
@@ -961,7 +961,7 @@ Phase 7-8 showed diminishing returns from seismological features (+0.003 per pha
 
 | Data Source | Status | Issue |
 |---|---|---|
-| NMDB cosmic rays | ✅ 14,565 records (IRKT/OULU/PSNM) | — |
+| NMDB cosmic rays | ✅ 14,685 records (3 stations; expanding to 9) | — |
 | Blitzortung lightning | ❌ JSONDecodeError | Archive returns HTML (access restricted), not detected |
 | INTERMAGNET hourly | ❌ HTTP 400 on all requests | 3 API parameter errors: `SamplesPerDay=24` (invalid), date format with TZ, wrong publicationState |
 | Movebank animal GPS | ❌ No data | No public GPS tracking studies in Japan region |
@@ -1287,7 +1287,7 @@ GCP プロジェクト `data-platform-490901` の `geohazard` データセット
 - Ionosphere TEC: CODE (University of Bern), Nagoya University ISEE GNSS-TEC
 - Land Surface Temperature: NASA MODIS MOD11A1 via LAADS DAAC
 - GEONET: 国土地理院 (Geospatial Information Authority of Japan)
-- Cosmic rays: NMDB (Neutron Monitor Database, nmdb.eu), operated by IRKT/OULU/PSNM stations
+- Cosmic rays: NMDB (Neutron Monitor Database, nmdb.eu), operated by 9 NMDB stations (IRKT/OULU/PSNM/APTY/JUNG/ATHN/ROME/BKSN/AATB)
 - Animal tracking: Movebank (movebank.org), Max Planck Institute of Animal Behavior
 - Lightning: Blitzortung.org community lightning network, University of Bonn sferics archive, NASA WWLLN (Univ. of Washington) via GHRC DAAC, NASA ISS LIS via GHRC DAAC
 - Satellite EM: CSES-Limadou (ASI/SSDC), INTERMAGNET (BGS Edinburgh GIN)

--- a/scripts/fetch_nmdb_cosmicray.py
+++ b/scripts/fetch_nmdb_cosmicray.py
@@ -10,10 +10,18 @@ Mechanism: crustal stress changes alter geomagnetic field → changes cosmic ray
 deflection patterns. Use daily rate anomalies (deviation from 27-day solar
 rotation mean) as precursor features.
 
-Stations:
-    IRKT (Irkutsk, Russia, 52.47°N, 104.03°E) - closest to Japan, 3.64 GV
-    OULU (Oulu, Finland, 65.05°N, 25.47°E) - reference, longest record, 0.81 GV
-    PSNM (Doi Inthanon, Thailand, 18.59°N, 98.49°E) - equatorial, 16.8 GV
+Stations (9 total, rigidity 0.65-16.80 GV):
+    Core 3 (since project start):
+        IRKT (Irkutsk, Russia)        - 3.64 GV  - closest to Japan
+        OULU (Oulu, Finland)          - 0.81 GV  - reference, longest record
+        PSNM (Doi Inthanon, Thailand) - 16.80 GV - equatorial
+    Stage 3 expansion (2026-05, mid-rigidity fill + global summed-rate density):
+        APTY (Apatity, Russia, polar) - 0.65 GV  - complements OULU
+        JUNG (Jungfraujoch, Swiss)    - 4.49 GV  - high altitude (3570m)
+        ATHN (Athens, Greece)         - 8.53 GV  - mid-Mediterranean
+        ROME (Rome, Italy)            - 6.27 GV  - sea-level European
+        BKSN (Baksan, Russia/Caucasus)- 5.70 GV  - mid-Eurasia
+        AATB (Alma-Ata B, Kazakhstan) - 5.90 GV  - high-altitude central Asia (3340m)
 
 References:
     - Homola et al. (2023) J. Atmos. Sol.-Terr. Phys. 247:106068
@@ -38,9 +46,17 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(me
 logger = logging.getLogger(__name__)
 
 STATIONS = {
+    # Core 3 (rigidity diversity: 0.81 / 3.64 / 16.80 GV)
     "IRKT": {"lat": 52.47, "lon": 104.03, "name": "Irkutsk", "rigidity_gv": 3.64},
     "OULU": {"lat": 65.05, "lon": 25.47, "name": "Oulu", "rigidity_gv": 0.81},
     "PSNM": {"lat": 18.59, "lon": 98.49, "name": "Doi Inthanon", "rigidity_gv": 16.8},
+    # Mid-rigidity fill (4-9 GV) + global summed-rate density (Stage 3)
+    "APTY": {"lat": 67.55, "lon": 33.39, "name": "Apatity", "rigidity_gv": 0.65},
+    "JUNG": {"lat": 46.55, "lon": 7.98,  "name": "Jungfraujoch", "rigidity_gv": 4.49},
+    "ATHN": {"lat": 37.97, "lon": 23.78, "name": "Athens", "rigidity_gv": 8.53},
+    "ROME": {"lat": 41.90, "lon": 12.52, "name": "Rome", "rigidity_gv": 6.27},
+    "BKSN": {"lat": 43.28, "lon": 42.69, "name": "Baksan", "rigidity_gv": 5.70},
+    "AATB": {"lat": 43.04, "lon": 76.94, "name": "Alma-Ata B", "rigidity_gv": 5.90},
 }
 
 NMDB_API = "https://www.nmdb.eu/nest/draw_graph.php"


### PR DESCRIPTION
## Summary
- Expand `STATIONS` dict in `scripts/fetch_nmdb_cosmicray.py` from **3 → 9** entries (adds APTY/JUNG/ATHN/ROME/BKSN/AATB)
- Bump cosmic_ray fetch step `timeout-minutes` 20 → 35 (initial 6-station backfill ≈ 18 min on top of existing ≈ 9 min)
- Sync README.md (3 mentions) + DATA_LICENSES.md (per-station license entries)

## Rationale
Stage 3 partial-coverage improvement targeting `cosmic_ray` (~87% station-day coverage). The Homola et al. (2023, J. Atmos. Sol.-Terr. Phys. 247:106068) >6σ correlation between cosmic-ray intensity and global summed M≥4 EQ count uses **global summed-rate** as the primary feature — denser station network → less noisy signal.

## Station selection (probed 40 NMDB stations)

| Station | Country | R [GV] | Alt [m] | 2011-01 | 2026-04 | Role |
|---------|---------|--------|---------|---------|---------|------|
| **APTY** | Russia (polar) | 0.65 | 181 | 31/31 | 30/30 | Polar low-rigidity (complements OULU) |
| **JUNG** | Switzerland | 4.49 | 3570 | 31/31 | 30/30 | High-altitude mid-rigidity |
| **ATHN** | Greece | 8.53 | 260 | 31/31 | 22/30 | Mid-Mediterranean |
| **ROME** | Italy | 6.27 | 0 | 24/31 | 30/30 | Sea-level European |
| **BKSN** | Russia/Caucasus | 5.70 | 1700 | 31/31 | 30/30 | Mid-Eurasia |
| **AATB** | Kazakhstan | 5.90 | 3340 | 31/31 | 30/30 | High-altitude central Asia |

Rejected candidates:
- **MOSC / NEWK / KIEL** — had 2011 baseline but **0 days reporting in 2026-04** (no longer real-time on NMDB)
- **DJON / JBGO / YKTK** — no 2011 baseline (mission start later than backfill window)

Rigidity coverage now spans **0.65 – 16.80 GV** (was 0.81 – 16.80; mid-rigidity 4–9 GV gap filled).

## Expected impact
- Row count: 14,685 → ~50,000+ over time (3.4x)
- Initial backfill: ~18 min/cron added (one-shot, then existing-keys skip)
- Steady-state: ~no overhead (month-first-day check skips populated months)

## Side-effect verification (downstream consumers)
- `scripts/cosmic_ray_analysis.py:115` uses hardcoded `["IRKT","OULU","PSNM"]` list — off cron path (manual analysis), intentionally narrow scope. Will silently miss new stations until updated separately.
- `scripts/ml_prediction.py:1266` queries `WHERE station = 'IRKT'` — single-station feature, unaffected.
- `src/features.py:120` comment-only (`"(IRKT)"`) — no functional change.

## Test plan
- [x] AST parse: STATIONS dict has 9 entries with `{lat, lon, name, rigidity_gv}` schema
- [x] CRLF preserved on README.md (`file README.md` reports CRLF)
- [x] All 6 new stations probed for 2011-01 + 2026-04 NMDB reachability
- [x] Coordinates cross-checked against NMDB published refs (no hemisphere errors)
- [ ] Next cron run: verify cosmic_ray step completes within 35-min budget
- [ ] BQ cosmic_ray row count grows 14,685 → 25,000+ within 1-2 cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded cosmic ray data collection to 9 total neutron monitor stations worldwide, adding coverage from 6 new locations.

* **Documentation**
  * Updated documentation and data attribution to reflect the enlarged monitoring station network and corresponding data sources.

* **Chores**
  * Increased data fetch timeout to support the expanded collection scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->