### PR TITLE
fix(backfill): distinguish timeout from corruption in post-restore integrity check

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -273,9 +273,12 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            if [ $? -ne 0 ]; then
-              echo "Existing DB is corrupt -- removing and re-initialising"
+            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
+            ic_rc=$?
+            if [ $ic_rc -eq 124 ]; then
+              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
+            elif [ $ic_rc -ne 0 ]; then
+              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
               rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
               NEEDS_INIT=1
             fi
@@ -517,9 +520,12 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            if [ $? -ne 0 ]; then
-              echo "Existing DB is corrupt -- removing and re-initialising"
+            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
+            ic_rc=$?
+            if [ $ic_rc -eq 124 ]; then
+              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
+            elif [ $ic_rc -ne 0 ]; then
+              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
               rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
               NEEDS_INIT=1
             fi
@@ -779,9 +785,12 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            if [ $? -ne 0 ]; then
-              echo "Existing DB is corrupt -- removing and re-initialising"
+            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
+            ic_rc=$?
+            if [ $ic_rc -eq 124 ]; then
+              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
+            elif [ $ic_rc -ne 0 ]; then
+              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
               rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
               NEEDS_INIT=1
             fi
@@ -1071,9 +1080,12 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            if [ $? -ne 0 ]; then
-              echo "Existing DB is corrupt -- removing and re-initialising"
+            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
+            ic_rc=$?
+            if [ $ic_rc -eq 124 ]; then
+              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
+            elif [ $ic_rc -ne 0 ]; then
+              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
               rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
               NEEDS_INIT=1
             fi
@@ -1366,9 +1378,12 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            if [ $? -ne 0 ]; then
-              echo "Existing DB is corrupt -- removing and re-initialising"
+            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
+            ic_rc=$?
+            if [ $ic_rc -eq 124 ]; then
+              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
+            elif [ $ic_rc -ne 0 ]; then
+              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
               rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
               NEEDS_INIT=1
             fi
@@ -1675,9 +1690,12 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            if [ $? -ne 0 ]; then
-              echo "Existing DB is corrupt -- removing and re-initialising"
+            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
+            ic_rc=$?
+            if [ $ic_rc -eq 124 ]; then
+              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
+            elif [ $ic_rc -ne 0 ]; then
+              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
               rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
               NEEDS_INIT=1
             fi

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -273,15 +273,20 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            ic_rc=$?
-            if [ $ic_rc -eq 124 ]; then
-              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
-            elif [ $ic_rc -ne 0 ]; then
-              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
-              rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
-              NEEDS_INIT=1
-            fi
+            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+            integrity_rc=$?
+            case "$integrity_rc" in
+              124|137|143)
+                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                ;;
+              0)
+                ;;
+              *)
+                echo "Existing DB is corrupt (rc=$integrity_rc) -- removing and re-initialising"
+                rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                NEEDS_INIT=1
+                ;;
+            esac
           fi
           if [ "$NEEDS_INIT" = "1" ]; then
             python3 -c "
@@ -520,15 +525,20 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            ic_rc=$?
-            if [ $ic_rc -eq 124 ]; then
-              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
-            elif [ $ic_rc -ne 0 ]; then
-              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
-              rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
-              NEEDS_INIT=1
-            fi
+            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+            integrity_rc=$?
+            case "$integrity_rc" in
+              124|137|143)
+                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                ;;
+              0)
+                ;;
+              *)
+                echo "Existing DB is corrupt (rc=$integrity_rc) -- removing and re-initialising"
+                rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                NEEDS_INIT=1
+                ;;
+            esac
           fi
           if [ "$NEEDS_INIT" = "1" ]; then
             python3 -c "
@@ -785,15 +795,20 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            ic_rc=$?
-            if [ $ic_rc -eq 124 ]; then
-              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
-            elif [ $ic_rc -ne 0 ]; then
-              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
-              rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
-              NEEDS_INIT=1
-            fi
+            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+            integrity_rc=$?
+            case "$integrity_rc" in
+              124|137|143)
+                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                ;;
+              0)
+                ;;
+              *)
+                echo "Existing DB is corrupt (rc=$integrity_rc) -- removing and re-initialising"
+                rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                NEEDS_INIT=1
+                ;;
+            esac
           fi
           if [ "$NEEDS_INIT" = "1" ]; then
             python3 -c "
@@ -1080,15 +1095,20 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            ic_rc=$?
-            if [ $ic_rc -eq 124 ]; then
-              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
-            elif [ $ic_rc -ne 0 ]; then
-              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
-              rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
-              NEEDS_INIT=1
-            fi
+            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+            integrity_rc=$?
+            case "$integrity_rc" in
+              124|137|143)
+                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                ;;
+              0)
+                ;;
+              *)
+                echo "Existing DB is corrupt (rc=$integrity_rc) -- removing and re-initialising"
+                rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                NEEDS_INIT=1
+                ;;
+            esac
           fi
           if [ "$NEEDS_INIT" = "1" ]; then
             python3 -c "
@@ -1378,15 +1398,20 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            ic_rc=$?
-            if [ $ic_rc -eq 124 ]; then
-              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
-            elif [ $ic_rc -ne 0 ]; then
-              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
-              rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
-              NEEDS_INIT=1
-            fi
+            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+            integrity_rc=$?
+            case "$integrity_rc" in
+              124|137|143)
+                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                ;;
+              0)
+                ;;
+              *)
+                echo "Existing DB is corrupt (rc=$integrity_rc) -- removing and re-initialising"
+                rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                NEEDS_INIT=1
+                ;;
+            esac
           fi
           if [ "$NEEDS_INIT" = "1" ]; then
             python3 -c "
@@ -1690,15 +1715,20 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 600 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null
-            ic_rc=$?
-            if [ $ic_rc -eq 124 ]; then
-              echo "::warning::full integrity check timed out (rc=124) -- keeping DB (quick check passed at restore step)"
-            elif [ $ic_rc -ne 0 ]; then
-              echo "Existing DB is corrupt (rc=$ic_rc) -- removing and re-initialising"
-              rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
-              NEEDS_INIT=1
-            fi
+            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+            integrity_rc=$?
+            case "$integrity_rc" in
+              124|137|143)
+                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                ;;
+              0)
+                ;;
+              *)
+                echo "Existing DB is corrupt (rc=$integrity_rc) -- removing and re-initialising"
+                rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                NEEDS_INIT=1
+                ;;
+            esac
           fi
           if [ "$NEEDS_INIT" = "1" ]; then
             python3 -c "


### PR DESCRIPTION
## Summary

5/5 05:46Z cron run reset the **light DB** because the post-restore full integrity check (`timeout 300`) hit the 5-min budget on a grown ~1.87 GB DB and was misinterpreted as corruption — the script removed the DB and re-initialised it. This destroyed 25 light-artifact tables.

The restore step had already validated the artifact via quick check (16s, `--mode=quick`) before this point, so a full check **timeout** should not destroy the DB. The fix distinguishes timeout from real corruption.

## Changes (6 jobs: light + fetch-modis/so2/cloud/snet/hinet)

- `timeout 300` → `timeout 600` (margin for growing DB; full check normally 124s per Measure Integrity workflow)
- Capture `ic_rc=$?` after the check
- `rc=124` (timeout) → warning only, preserve DB
- `rc!=0 && rc!=124` (real corruption) → reset DB (existing behavior)
- `rc=0` → normal (existing)

Diff: `1 file changed, 36 insertions(+), 18 deletions(-)`

## Incident background

5/5 05:46Z run (job 74357886362, head `92b4326` PR #136 base) restored a checkpoint successfully (quick check passed) but the post-restore full check `timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null` timed out at 06:08:42Z → \"Existing DB is corrupt -- removing and re-initialising\" → \`init_db()\` re-created empty schema.

Cascade: subsequent fetchers ran from empty state. WRITE_TRUNCATE propagated empty/partial state to BQ.

## Tables impacted (25 light-artifact tables)

**Recovered same day** (USGS / NOAA / WDC / NMDB sources allow full re-fetch): earthquakes, focal_mechanisms, earth_rotation, geomag_kp, geomag_hourly, goes_proton, goes_xray, tidal_stress, solar_wind, particle_flux, olr, cosmic_ray (now 47K rows from PR #136), tide_gauge, gravity_mascon, soil_moisture, lightning_lis_otd, lightning_thunder_hour, nightlight, ocean_color, dart_pressure

**Still recovering** (oldest-first / capped fetcher rate):
| Table | Now | Was | Recovery ETA |
|---|---|---|---|
| ulf_magnetic | 7.78M / 1800 days | 24.18M / 5594 days | ~2.5 days |
| tec | 1.14M / 885 days | 6.4M / 5605 days | ~3.9 days |
| gnss_tec | 1.25M / max 2014-04-14 | 5.26M / max 2024-11-20 | ~2.75 days |
| iss_lis_lightning | 1,046 / max 2017-12-03 | 7,311 / max 2023-08-05 | ~9 days |
| swarm_em | 1,626 / max 2015-06-24 | (mission 2014-2019) | 5-7 days |
| ioc_sea_level | 2.07M / 180 days | (was 277 days) | ~30 days ⚠️ |

## Unaffected (separate artifacts)

snet_waveform, fnet_waveform, hinet_waveform, modis_lst, so2_column, cloud_fraction — these tables live in their own fetch-job artifacts (PR #132 design), not the light DB. They are unaffected.

## Test plan

- [x] YAML safe_load OK on RPi5 (`yaml.safe_load` returns 8 jobs as expected)
- [x] grep verification: `timeout 600 python3 scripts/check_db_integrity` = 6 occurrences; `timeout 300` = 0 occurrences
- [x] Verified replacement structure preserves `rm -f` cleanup logic for real-corruption path
- [ ] Production validation: next cron run with `92b4326` HEAD (post-merge) should not trigger a false-corrupt reset; `::warning::full integrity check timed out` may surface if DB grows further

## Future stages (not in this PR)

- **Stage 2**: replace destructive reinit-on-failure with multi-checkpoint fallback + salvage_db.py per-table recovery
- **Stage 3**: BQ incremental upload so SQLite reset doesn't propagate via WRITE_TRUNCATE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database integrity checks in data processing workflows with improved timeout handling and error recovery to increase reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->