### PR TITLE
feat(load_raw_to_bq): add BQ regression guard against SQLite data loss

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2310,6 +2310,11 @@ jobs:
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          # Repository Variable: set to 'true' during initial recovery period
+          # to bypass regression guard (otherwise still-recovering tables would
+          # be locked out of BQ updates). Unset / set to 'false' once tables
+          # are back to baseline so the guard can catch future incidents.
+          BQ_FORCE_OVERWRITE: ${{ vars.BQ_FORCE_OVERWRITE }}
         run: python3 scripts/load_raw_to_bq.py
 
       - name: Notify Discord

--- a/scripts/load_raw_to_bq.py
+++ b/scripts/load_raw_to_bq.py
@@ -428,6 +428,13 @@ TABLES = {
 # when the DB is empty or corrupted.
 MIN_ROWS_TO_UPLOAD = 1000
 
+# Regression guard: if SQLite count is below REGRESSION_THRESHOLD * BQ count,
+# skip the upload. 0.5 (50%) catches catastrophic data loss (5/5 05:46Z
+# incident SQLite was 14-32% of BQ for affected tables). Higher values
+# (e.g. 0.7) would trigger on minor transient losses; lower values would
+# miss meaningful losses. Bypass with env BQ_FORCE_OVERWRITE=true.
+REGRESSION_THRESHOLD = 0.5
+
 # Per-table override for the minimum-row threshold.
 # Some tables are sparse by design (event-targeted backfill, rare phenomena)
 # and would never reach the global 1000-row floor in their bootstrap phase.
@@ -466,6 +473,62 @@ def _sanitize(v):
     if isinstance(v, float) and not math.isfinite(v):
         return None
     return v
+
+
+def _query_bq_count(client, bq_table):
+    """Return current row count of bq_table, or 0 if table missing / query fails.
+
+    Used by the regression guard. Fail-open semantics: BQ NotFound (first-time
+    table creation) and any transient error (network, auth, quota) return 0
+    so we never block a legitimate upload on a BQ glitch. The cost is that
+    we also miss the regression catch on those rare error paths, which is
+    acceptable since the original threshold (MIN_ROWS_TO_UPLOAD) still
+    protects against fully empty SQLite.
+    """
+    from google.api_core import exceptions as google_exceptions
+    try:
+        result = client.query(f"SELECT COUNT(*) AS n FROM `{bq_table}`").result()
+        for row in result:
+            return row[0]
+        return 0
+    except google_exceptions.NotFound:
+        return 0
+    except Exception as e:
+        logger.warning(
+            "BQ count query failed for %s (%s) — fail-open returning 0",
+            bq_table, type(e).__name__,
+        )
+        return 0
+
+
+def _should_skip_regression(client, bq_table, sqlite_count, table_name):
+    """Return True if BQ upload should be skipped due to regression vs current BQ count.
+
+    Decision logic:
+    - BQ_FORCE_OVERWRITE=true env -> always allow (returns False)
+    - BQ count == 0 (table missing or query failed) -> allow (first-time creation)
+    - SQLite count >= REGRESSION_THRESHOLD * BQ count -> allow
+    - Otherwise -> skip (returns True)
+
+    Logs a warning when bypassing or skipping so the operator can audit.
+    """
+    if os.environ.get("BQ_FORCE_OVERWRITE", "").lower() == "true":
+        logger.warning("%s: BQ_FORCE_OVERWRITE=true — bypassing regression guard",
+                       table_name)
+        return False
+    bq_count = _query_bq_count(client, bq_table)
+    if bq_count == 0:
+        return False
+    ratio = sqlite_count / bq_count
+    if ratio < REGRESSION_THRESHOLD:
+        logger.warning(
+            "%s: regression detected (SQLite %d = %.0f%% of BQ %d) — "
+            "skipping. Set env BQ_FORCE_OVERWRITE=true to bypass for legitimate "
+            "shrinkage (data cleanup, schema migration).",
+            table_name, sqlite_count, ratio * 100, bq_count,
+        )
+        return True
+    return False
 
 
 def main():
@@ -513,9 +576,16 @@ def main():
                                 table_name, count, threshold)
                     continue
 
-                logger.info("%s: streaming %d rows to gzip NDJSON...", table_name, count)
-
                 bq_table = f"{PROJECT}.{DATASET}.{table_name}"
+
+                # Regression guard: catch SQLite data loss before WRITE_TRUNCATE
+                # propagates it to BQ. See _should_skip_regression() docstring.
+                # Background: 5/5 05:46Z incident reset 25 light-artifact tables;
+                # PR #137 fixed the trigger, this guard adds defense in depth.
+                if _should_skip_regression(client, bq_table, count, table_name):
+                    continue
+
+                logger.info("%s: streaming %d rows to gzip NDJSON...", table_name, count)
                 schema = [bigquery.SchemaField(s["name"], s["type"]) for s in config["schema"]]
 
                 job_config = bigquery.LoadJobConfig(

--- a/scripts/load_raw_to_bq.py
+++ b/scripts/load_raw_to_bq.py
@@ -492,13 +492,13 @@ def _query_bq_count(client, bq_table):
     permission glitches independently (weekly check of regression-guard logs).
     """
     try:
-        result = client.query(f"SELECT COUNT(*) AS n FROM `{bq_table}`").result()
+        result = client.query(f"SELECT COUNT(*) AS n FROM `{bq_table}`").result()  # noqa: S608
         for row in result:
             return int(row[0] or 0)
         return 0
     except google_exceptions.NotFound:
         return 0
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001  # fail-open: guard must not block legitimate uploads
         logger.warning(
             "BQ count query failed for %s (%s) — fail-open returning 0",
             bq_table, type(e).__name__,

--- a/scripts/load_raw_to_bq.py
+++ b/scripts/load_raw_to_bq.py
@@ -16,6 +16,11 @@ import sqlite3
 import sys
 import tempfile
 
+# google-api-core is a transitive dependency of google-cloud-bigquery (loaded
+# lazily inside main()). Importing here at module top is safe because RPi5
+# smoke test stubs google.api_core.exceptions in sys.modules before importing.
+from google.api_core import exceptions as google_exceptions
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -483,13 +488,13 @@ def _query_bq_count(client, bq_table):
     so we never block a legitimate upload on a BQ glitch. The cost is that
     we also miss the regression catch on those rare error paths, which is
     acceptable since the original threshold (MIN_ROWS_TO_UPLOAD) still
-    protects against fully empty SQLite.
+    protects against fully empty SQLite. Operators must monitor for sustained
+    permission glitches independently (weekly check of regression-guard logs).
     """
-    from google.api_core import exceptions as google_exceptions
     try:
         result = client.query(f"SELECT COUNT(*) AS n FROM `{bq_table}`").result()
         for row in result:
-            return row[0]
+            return int(row[0] or 0)
         return 0
     except google_exceptions.NotFound:
         return 0
@@ -507,8 +512,14 @@ def _should_skip_regression(client, bq_table, sqlite_count, table_name):
     Decision logic:
     - BQ_FORCE_OVERWRITE=true env -> always allow (returns False)
     - BQ count == 0 (table missing or query failed) -> allow (first-time creation)
-    - SQLite count >= REGRESSION_THRESHOLD * BQ count -> allow
+    - SQLite count >= REGRESSION_THRESHOLD * BQ count -> allow (boundary inclusive:
+      ratio == 0.5 passes; ratio < 0.5 skips)
     - Otherwise -> skip (returns True)
+
+    Known limitation: with REGRESSION_THRESHOLD = 0.5, a 40-50% partial data
+    loss still passes through. Tighter thresholds (0.7+) would catch more but
+    risk false-positive on legitimate cleanup operations. The 5/5 incident
+    scenarios were 14-32% so 0.5 retains comfortable margin.
 
     Logs a warning when bypassing or skipping so the operator can audit.
     """
@@ -522,7 +533,7 @@ def _should_skip_regression(client, bq_table, sqlite_count, table_name):
     ratio = sqlite_count / bq_count
     if ratio < REGRESSION_THRESHOLD:
         logger.warning(
-            "%s: regression detected (SQLite %d = %.0f%% of BQ %d) — "
+            "%s: regression detected (SQLite %d = %.1f%% of BQ %d) — "
             "skipping. Set env BQ_FORCE_OVERWRITE=true to bypass for legitimate "
             "shrinkage (data cleanup, schema migration).",
             table_name, sqlite_count, ratio * 100, bq_count,

--- a/scripts/smoke_test_bq_regression_guard.py
+++ b/scripts/smoke_test_bq_regression_guard.py
@@ -1,0 +1,141 @@
+"""Smoke tests for BQ regression guard in load_raw_to_bq.py.
+
+Tests _query_bq_count() and _should_skip_regression() in isolation using
+mock bigquery client. RPi5 does not have google-cloud-bigquery installed,
+so we stub the google.* modules in sys.modules before importing.
+
+Verifies:
+- 5/5 incident scenarios block upload (regression detection works)
+- Normal growth and table creation pass through
+- Threshold boundary (50%) behavior
+- BQ_FORCE_OVERWRITE=true bypass (case-insensitive)
+- Transient BQ errors fail-open (allow upload)
+"""
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# Stub google.* modules before importing load_raw_to_bq, since the helper
+# does a lazy import of google.api_core.exceptions inside _query_bq_count.
+class _StubNotFound(Exception):
+    pass
+
+
+_google = types.ModuleType("google")
+_api_core = types.ModuleType("google.api_core")
+_exceptions = types.ModuleType("google.api_core.exceptions")
+_exceptions.NotFound = _StubNotFound
+_cloud = types.ModuleType("google.cloud")
+_bigquery = types.ModuleType("google.cloud.bigquery")
+
+sys.modules.setdefault("google", _google)
+sys.modules.setdefault("google.api_core", _api_core)
+sys.modules.setdefault("google.api_core.exceptions", _exceptions)
+sys.modules.setdefault("google.cloud", _cloud)
+sys.modules.setdefault("google.cloud.bigquery", _bigquery)
+
+# Now safe to import the module under test
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import load_raw_to_bq  # noqa: E402
+
+
+def _mock_client_returning(rows):
+    """Create a mock client whose query().result() yields rows."""
+    client = MagicMock()
+    result_mock = MagicMock()
+    result_mock.__iter__.return_value = iter(rows)
+    client.query.return_value.result.return_value = result_mock
+    return client
+
+
+def _mock_client_raising(exc):
+    client = MagicMock()
+    client.query.side_effect = exc
+    return client
+
+
+class TestQueryBqCount(unittest.TestCase):
+    def test_returns_count_from_first_row(self):
+        client = _mock_client_returning([(12345,)])
+        self.assertEqual(load_raw_to_bq._query_bq_count(client, "p.d.t"), 12345)
+
+    def test_not_found_returns_zero(self):
+        client = _mock_client_raising(_StubNotFound("missing"))
+        self.assertEqual(load_raw_to_bq._query_bq_count(client, "p.d.missing"), 0)
+
+    def test_generic_exception_returns_zero_fail_open(self):
+        client = _mock_client_raising(RuntimeError("transient boom"))
+        self.assertEqual(load_raw_to_bq._query_bq_count(client, "p.d.t"), 0)
+
+    def test_empty_result_returns_zero(self):
+        client = _mock_client_returning([])
+        self.assertEqual(load_raw_to_bq._query_bq_count(client, "p.d.t"), 0)
+
+
+class TestShouldSkipRegression(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("BQ_FORCE_OVERWRITE", None)
+
+    def tearDown(self):
+        os.environ.pop("BQ_FORCE_OVERWRITE", None)
+
+    def test_5_5_ulf_magnetic_32pct_blocks(self):
+        # SQLite 7,776,000 vs BQ 24,179,040 = 32% < 50% threshold
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=24179040):
+            self.assertTrue(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.ulf_magnetic", 7776000, "ulf_magnetic"))
+
+    def test_5_5_iss_lis_14pct_blocks(self):
+        # SQLite 1,046 vs BQ 7,311 = 14%
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=7311):
+            self.assertTrue(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.iss_lis_lightning", 1046, "iss_lis_lightning"))
+
+    def test_growth_ratio_110pct_passes(self):
+        # snet healthy growth: 973,228 vs 886,626 = 110%
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=886626):
+            self.assertFalse(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.snet_waveform", 973228, "snet_waveform"))
+
+    def test_exactly_50pct_passes(self):
+        # ratio == 0.5, NOT < 0.5 => allow
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=2000):
+            self.assertFalse(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.t", 1000, "t"))
+
+    def test_just_below_50pct_blocks(self):
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=2000):
+            self.assertTrue(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.t", 999, "t"))
+
+    def test_first_time_table_creation_passes(self):
+        # bq_count == 0 (NotFound or empty) => allow
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=0):
+            self.assertFalse(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.brand_new", 100, "brand_new"))
+
+    def test_force_overwrite_true_bypasses(self):
+        os.environ["BQ_FORCE_OVERWRITE"] = "true"
+        # Even at 1% ratio, env var bypasses guard
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=10000):
+            self.assertFalse(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.t", 100, "t"))
+
+    def test_force_overwrite_TRUE_uppercase_bypasses(self):
+        os.environ["BQ_FORCE_OVERWRITE"] = "TRUE"
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=10000):
+            self.assertFalse(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.t", 100, "t"))
+
+    def test_force_overwrite_false_string_does_not_bypass(self):
+        os.environ["BQ_FORCE_OVERWRITE"] = "false"
+        with patch.object(load_raw_to_bq, "_query_bq_count", return_value=10000):
+            self.assertTrue(load_raw_to_bq._should_skip_regression(
+                MagicMock(), "p.d.t", 100, "t"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/smoke_test_bq_regression_guard.py
+++ b/scripts/smoke_test_bq_regression_guard.py
@@ -18,10 +18,18 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 
-# Stub google.* modules before importing load_raw_to_bq, since the helper
-# does a lazy import of google.api_core.exceptions inside _query_bq_count.
-class _StubNotFound(Exception):
-    pass
+# Stub google.* modules before importing load_raw_to_bq.
+# When google-cloud-bigquery is actually installed (e.g. CI env with the
+# library), inherit from the real NotFound so _query_bq_count's
+#  branch is exercised correctly.
+# On RPi5 (no google library), fall back to bare Exception subclass.
+try:
+    from google.api_core.exceptions import NotFound as _RealNotFound  # type: ignore[import]
+    class _StubNotFound(_RealNotFound):
+        pass
+except ImportError:
+    class _StubNotFound(Exception):  # type: ignore[no-redef]
+        pass
 
 
 _google = types.ModuleType("google")


### PR DESCRIPTION
## Summary

Stage 3 defense for the 5/5 05:46Z incident class. PR #137 fixed the trigger (post-restore integrity check timeout misjudged as corruption); this guard adds a final layer that prevents future SQLite data loss from propagating to BQ via WRITE_TRUNCATE.

## Mechanism

Before each WRITE_TRUNCATE in `load_raw_to_bq.py`:
1. Query current BQ row count (cheap metadata query, no scan)
2. If `SQLite_count / BQ_count < REGRESSION_THRESHOLD` (0.5), skip the upload and log a warning
3. Bypass with env `BQ_FORCE_OVERWRITE=true` (Repository Variable)

## How 5/5 incident would have been handled

| Table | SQLite (post-reset) | BQ (pre-reset) | Ratio | Guard |
|---|---|---|---|---|
| ulf_magnetic | 7.78M | 24.18M | 32% | ✅ skip |
| iss_lis_lightning | 1,046 | 7,311 | 14% | ✅ skip |
| gnss_tec | 1.25M | 5.26M | 24% | ✅ skip |
| tec | 1.14M | 6.4M | 18% | ✅ skip |
| swarm_em | 1,626 | (lost) | <50% likely | ✅ skip |

BQ would have stayed at the pre-reset values until SQLite recovered above 50%, at which point the natural WRITE_TRUNCATE would have caught BQ up.

## Files changed

### `scripts/load_raw_to_bq.py` (+72 / -2)
- New constant `REGRESSION_THRESHOLD = 0.5` (catches 5/5 scenarios at 14-32%; tighter would trigger on minor transient losses, looser would miss meaningful loss)
- New helper `_query_bq_count(client, bq_table) -> int` — fail-open semantics (NotFound or any exception returns 0 to allow first-time creation and not block on transient BQ glitches)
- New helper `_should_skip_regression(client, bq_table, count, table_name) -> bool` — encapsulates env check + ratio comparison
- Inline call in upload loop after existing `MIN_ROWS_TO_UPLOAD` threshold

### `.github/workflows/backfill.yml` (+5)
- Pass `vars.BQ_FORCE_OVERWRITE` through env to `load_raw_to_bq.py` invocation

### `scripts/smoke_test_bq_regression_guard.py` (new, 13 tests)
- `_query_bq_count`: normal / NotFound / generic exception / empty result (4)
- `_should_skip_regression`: 5/5 ulf 32% blocks, iss_lis 14% blocks, growth 110% passes, exactly 50% passes, just below 50% blocks, first-time creation passes, FORCE_OVERWRITE true/TRUE bypasses, false does not (9)
- All 13 PASS on RPi5 (sys.modules stub for google-api-core which is not installed)

## Deployment plan

1. **Repository Variable `BQ_FORCE_OVERWRITE=true` already set** (5/6 01:39Z) — bypass guard during ongoing 22-table reset recovery
2. After PR merge, guard code is live but bypassed by env var
3. Monitor 22 affected tables for recovery (ETAs from PR #137: ulf 2.5d / tec 3.9d / gnss_tec 2.75d / iss_lis 9d / swarm_em 5-7d / ioc 30d)
4. **Once ioc_sea_level recovery completes (~2026-06-05)**, delete the Repository Variable so guard activates

If deployed without the bypass, the 6 still-recovering tables (32% / 14% / 24% / 18% / unknown / 8%) would all be blocked from BQ updates, freezing BQ at incident-low values. The bypass prevents this counter-productive lock-out.

## Cost

- 31 BQ `COUNT(*)` queries per cron run = ~248/day
- COUNT(*) uses table snapshot metadata, not full scan — essentially free in BigQuery
- Well within free tier

## Test plan

- [x] AST parse OK
- [x] 13 smoke tests PASS on RPi5 (`python3 scripts/smoke_test_bq_regression_guard.py`)
- [x] YAML safe_load OK
- [x] Repository Variable BQ_FORCE_OVERWRITE=true verified via `gh api repos/yasumorishima/japan-geohazard-monitor/actions/variables`
- [ ] Production validation: next cron run with `BQ_FORCE_OVERWRITE=true` env should bypass guard, BQ uploads as normal (logs `bypassing regression guard`); after recovery + variable removal, future incidents should produce `regression detected ... skipping` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added regression guard to prevent accidental data loss during BigQuery uploads by detecting when a table would contain fewer rows than currently stored
  * Added `BQ_FORCE_OVERWRITE` flag to bypass the regression guard when intentional data adjustments are required

* **Tests**
  * Added comprehensive test coverage for the regression guard functionality across multiple scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->