### PR TITLE
fix(backfill): raise IOC sea level step timeout from 15 to 35 minutes

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2048,7 +2048,7 @@ jobs:
         id: fetch_ioc_sealevel
         if: inputs.target == 'all' || inputs.target == 'ioc_sealevel' || inputs.target == ''
         continue-on-error: true
-        timeout-minutes: 15
+        timeout-minutes: 35
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
           IOC_PARALLEL_FETCHES: ${{ vars.IOC_PARALLEL_FETCHES || '2' }}


### PR DESCRIPTION
## Summary
The IOC sea level fetch step has hardcoded `timeout-minutes: 15`, but Repository Variable `IOC_MAX_CHUNKS=300` (4x speedup vs default 72) was introduced 2026-05-06 to compress `ioc_sea_level` recovery ETA from ~14.7d to ~3.7d. Worst-case execution time under `IOC_MAX_CHUNKS=300` is ~25 minutes, exceeding the 15-minute step timeout.

**Observed in cron run [25448586828](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25448586828)** (2026-05-06 16:43Z trigger):
```
##[error]The action 'Fetch IOC sea level monitoring' has timed out after 15 minutes.
```

`continue-on-error: true` masked the failure at the cron-aggregate level (no Discord alert), but the step itself failed. The next cron run [25457367115](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25457367115) (19:47Z) completed in 10m14s — outcome was timing-dependent on gap distribution per cron, not consistent.

Following the same pattern as PR #136 (cosmic_ray station expansion 3→9, raised timeout 20→35), bump IOC sea level step to 35 minutes (~10min margin over worst-case ~25min).

## Scope
- `Fetch IOC sea level monitoring` (line 2051): `timeout-minutes: 15 → 35` ← only change
- `Fetch DART pressure` (line 2041): keeps 15 (unaffected by IOC vars)
- `Fetch IOC DART` (line 2067): keeps 15 (still uses default `IOC_DART_MAX_CHUNKS=72`, completes in <1 minute)

## Test plan
- [ ] CodeRabbit pass
- [ ] Next backfill cron after merge: confirm IOC sea level step completes within 35min budget without timeout
- [ ] Confirm no regression on cron-aggregate success rate or BQ row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of data fetching processes by adjusting timeout parameters to accommodate longer execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->