### PR TITLE
docs(README): fix 3 factual errors in PR #136 cosmic ray entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Front-stall observation: as part of the same session a 31-table BigQuery coverag
 
 ### Phase 2 (3) Cosmic ray station expansion ✅ (2026-05-04)
 
-PR #136 (master `92dac56`) expanded `fetch_cosmic_ray.py` from 3 NMDB stations (OULU/KIEL/MOSC) to 9 stations (added APTY/INVK/JUNG/MGDN/NEWK/SOPO/TERA) for global summed-rate density and improved Forbush-decrease detection latitude coverage. Total `cosmic_ray` rows grew to **47,018 rows** (2011-01-01 → 2026-05-05) at fixed 11-year retrospective coverage. Throughput cost: ~6 sec added per cron (NMDB API, BasicAuth, 1-req/station/day cycle), well within light-job budget. Feature `cosmic_ray_anomaly` reuses the same 27-day solar rotation baseline; the 9-station summed-rate denoises geomagnetically-induced bursts that single-station data could not separate from genuine anomalies.
+PR #136 (master `92dac56`) expanded `fetch_nmdb_cosmicray.py` from 3 NMDB stations (IRKT/OULU/PSNM) to 9 stations (added APTY/JUNG/ATHN/ROME/BKSN/AATB) for global summed-rate density and improved Forbush-decrease detection latitude coverage. Total `cosmic_ray` rows grew to **47,018 rows** (2011-01-01 → 2026-05-05) at fixed 11-year retrospective coverage. Throughput cost: ~6 sec added per cron (NMDB API, BasicAuth, 1-req/station/day cycle), well within light-job budget. Feature `cosmic_ray_anomaly` reuses the same 27-day solar rotation baseline; the 9-station summed-rate denoises geomagnetically-induced bursts that single-station data could not separate from genuine anomalies.
 
 ### Light-artifact reset incident + Stage 1 fix ✅ (2026-05-06)
 


### PR DESCRIPTION
## Summary
The PR #136 entry at README L467 contained 3 factual errors that did not match the actual PR #136 diff or the current source state of `scripts/fetch_nmdb_cosmicray.py` (L48 STATIONS dict). Discovered during Opus subagent review of PR #140 docs cadence.

| # | Field | Before (incorrect) | After (correct, source-of-truth verified) |
|---|---|---|---|
| 1 | Filename | `fetch_cosmic_ray.py` | `fetch_nmdb_cosmicray.py` |
| 2 | Core 3 stations | `OULU/KIEL/MOSC` | `IRKT/OULU/PSNM` |
| 3 | Added 6 stations | `APTY/INVK/JUNG/MGDN/NEWK/SOPO/TERA` (7 entries, also wrong count) | `APTY/JUNG/ATHN/ROME/BKSN/AATB` (6 entries) |

The rejected stations from the PR #136 20-station selection probe (MOSC/NEWK/KIEL dropped due to 2026-04 reporting = 0; DJON/JBGO/YKTK due to incomplete 2011 baseline) appear to have been confused with the actual additions in the original entry text.

The remaining content (47,018 row count, date range 2011-01-01 → 2026-05-05, throughput cost, feature impact) is correct and unchanged. **CRLF line endings preserved** (1359 unchanged), +1 / -1.

## Source of truth
- `scripts/fetch_nmdb_cosmicray.py` L48-60 STATIONS dict (Core 3: IRKT/OULU/PSNM at rigidity 3.64/0.81/16.80 GV; Added 6: APTY/JUNG/ATHN/ROME/BKSN/AATB at rigidity 0.65/4.49/8.53/6.27/5.70/5.90 GV)
- README L757-758 (`Data Sources` table) already contains the correct list (`9 stations (IRKT/OULU/PSNM/APTY/JUNG/...`); only L467 was stale.

## Test plan
- [ ] CodeRabbit pass
- [ ] Render check on GitHub (entry text matches README L757 Data Sources table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)