### PR TITLE
fix(workflow): restore step timeout-minutes 10->25 to prevent init_db rebuild on hot DB

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -396,7 +396,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -666,7 +666,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -966,7 +966,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -1272,7 +1272,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -1586,7 +1586,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}


### PR DESCRIPTION
## Summary

緊急 hotfix: 全 6 fetch jobs の `Restore previous database checkpoint` step の `timeout-minutes` を **10 → 25 分**に拡大。 5/5 reset 事故の root cause 再発を阻止。

## Root cause (cron 25491776405 実証)

`2026-05-07T12:15:09 ##[error]The action 'Restore previous database checkpoint' has timed out after 10 minutes.`

DB が 15 GB に肥大化 (通常 1.8 GB の 8 倍、 復旧期間 fetcher full backfill による free page 蓄積) → artifact (479 MB zip) download + extract が 10 分超え → step timeout。 continue-on-error: true で後続継続、 `Init DB if missing or corrupt` で `[ ! -f data/geohazard.db ]` 判定 → init_db rebuild → 25 tables empty → fetcher で再充足 (cosmic_ray 31m38s, INTERMAGNET 18m43s 等の異常時間が証拠) → snapshot で thin DB upload (179 MB) → BQ_FORCE_OVERWRITE=true により regression guard bypass → BQ も thin に伝搬。

## BQ 被害実測 (5/8 0:30Z 時点)

| table | 旧 row | 現 row | regression |
|-------|--------|--------|-----------|
| ulf_magnetic | 19.44M | 1.30M | -93% |
| tec | 2.85M | 189K | -93% |
| gnss_tec | 3.11M | 208K | -93% (max_date 8 年後退) |
| ioc_sea_level | 31.48M | 3.93M | -87% (max_date 3 年後退) |

## Why PR #137 didn't catch this

PR #137 (`f182e09`) は内部 `timeout 1200 python3 scripts/check_db_integrity.py` を 300 → 1200 sec に拡大したが、 これは post-restore integrity check の sub-shell timeout のみ。 step-level の `timeout-minutes: 10` は未修正で残存していた。 PR #137 文脈は「false-corrupt 判定で init_db 走った」 修正、 今回は「step 自体が timeout で続く check 起きず init_db 走った」 別経路。

## Changes

`.github/workflows/backfill.yml` の 6 箇所のみ:
- `fetch-modis` job (line 147)
- `fetch-so2` job (line 399)
- `fetch-cloud` job (line 669)
- `fetch-snet` job (line 969)
- `fetch-hinet` job (line 1275)
- `light` job (line 1589)

各 step の `id: restore` + `continue-on-error: true` + `timeout-minutes: 10` 3 行 block の最終行のみ `25` に変更 (replace_all uniqueness 確保)。 他の `timeout-minutes: 10` (line 1922 iers, line 2011 goes_proton) は影響なし。

## Why 25 (not 35 / 60)

15 GB DB の unzip + cp 推定 ~10-15 分 → 25 分で約 10 分余裕。 35-60 にすれば余裕大だがランナー時間消費 (cron 8 回/日 × 6 jobs × +n 分)。 25 が「余裕あり / コスト中」 のバランス。 中長期で DB 縮小 (snapshot script に VACUUM 追加) 別 PR で対処。

## Test plan

- [x] subagent (Opus) review (caller verify 必須)
- [ ] CodeRabbit / CodeQL pass
- [ ] merge
- [ ] PR merge 後に Repository Variable `BQ_FORCE_OVERWRITE` を削除 (default=false で guard 有効化)
- [ ] 次 cron で `Restore previous database checkpoint` step が成功 (`init_db` rebuild なし) 確認
- [ ] 数 cron 後に BQ row count が SQLite robust state を反映して復旧確認

## Risk

- **None**: timeout 拡大のみ、 logic 変更なし。 6 jobs それぞれ continue-on-error: true は維持
- 25 分でも timeout する場合は init_db 経路に再突入だが、 BQ_FORCE_OVERWRITE 削除済なら guard が thin upload 防衛
- 中長期の DB 縮小対策は別 PR で

## Out of scope (follow-up)

- DB 15 GB 肥大の根本対処 (snapshot script に `VACUUM` / `PRAGMA auto_vacuum = INCREMENTAL` 追加検討)
- 過去 robust checkpoint artifact (~5/4 期) からの直接 BQ 復旧 script
- PR #143 (iss_lis 並列化) の smoke 再実行は復旧完了後


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout thresholds for database restoration operations in automated workflows. This change provides additional time for database operations to complete successfully, improving overall reliability of scheduled backfill procedures and reducing timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->