### PR TITLE
fix(cloud): add diagnostic logging for HTTP 200 silent failure

### DIFF
--- a/scripts/fetch_cloud_fraction.py
+++ b/scripts/fetch_cloud_fraction.py
@@ -189,7 +189,24 @@ async def fetch_cloud_day(session: aiohttp.ClientSession, date: datetime) -> lis
         try:
             status, text = await earthdata_fetch(session, url, timeout=TIMEOUT)
             if status == 200:
-                if not text or "<html" in text[:200].lower():
+                if not text:
+                    diag_count = getattr(fetch_cloud_day, "_diag_silent", 0)
+                    if diag_count < 5:
+                        logger.warning(
+                            "Cloud %s: HTTP 200 empty body (silent failure)",
+                            date_str,
+                        )
+                        setattr(fetch_cloud_day, "_diag_silent", diag_count + 1)
+                    return []
+                if "<html" in text[:200].lower():
+                    diag_count = getattr(fetch_cloud_day, "_diag_silent", 0)
+                    if diag_count < 5:
+                        logger.warning(
+                            "Cloud %s: HTTP 200 HTML body (auth/redirect issue) "
+                            "len=%d preview=%r",
+                            date_str, len(text), text[:200],
+                        )
+                        setattr(fetch_cloud_day, "_diag_silent", diag_count + 1)
                     return []
                 return _parse_cloud_ascii(text, date_str)
             elif status in (401, 403):

--- a/scripts/fetch_cloud_fraction.py
+++ b/scripts/fetch_cloud_fraction.py
@@ -190,23 +190,23 @@ async def fetch_cloud_day(session: aiohttp.ClientSession, date: datetime) -> lis
             status, text = await earthdata_fetch(session, url, timeout=TIMEOUT)
             if status == 200:
                 if not text:
-                    diag_count = getattr(fetch_cloud_day, "_diag_silent", 0)
+                    diag_count = getattr(fetch_cloud_day, "_diag_empty", 0)
                     if diag_count < 5:
                         logger.warning(
                             "Cloud %s: HTTP 200 empty body (silent failure)",
                             date_str,
                         )
-                        setattr(fetch_cloud_day, "_diag_silent", diag_count + 1)
+                        fetch_cloud_day._diag_empty = diag_count + 1
                     return []
                 if "<html" in text[:200].lower():
-                    diag_count = getattr(fetch_cloud_day, "_diag_silent", 0)
+                    diag_count = getattr(fetch_cloud_day, "_diag_html", 0)
                     if diag_count < 5:
                         logger.warning(
                             "Cloud %s: HTTP 200 HTML body (auth/redirect issue) "
                             "len=%d preview=%r",
                             date_str, len(text), text[:200],
                         )
-                        setattr(fetch_cloud_day, "_diag_silent", diag_count + 1)
+                        fetch_cloud_day._diag_html = diag_count + 1
                     return []
                 return _parse_cloud_ascii(text, date_str)
             elif status in (401, 403):


### PR DESCRIPTION
## Why

`scripts/fetch_cloud_fraction.py` の `fetch_cloud_day` が `Cloud: 900/900 dates, 0 records` を返すケースで warning ログ皆無、 silent failure path が見えない問題。 cron 25523898337 (5/7 21:47Z) で確認:

- `test_earthdata_auth.py`: `Result: ALL PASS` (LAADS HTTP 200 / CMR HTTP 200 / GES DISC HTTP 200)
- fetcher 起動: `Cloud fraction: 900 dates to fetch` + `Earthdata session created (Bearer token available, len=673)`
- 全 900 dates で 0 records、 警告 0 件

`fetch_cloud_day` の `if status == 200: if not text or "<html" in text[:200].lower(): return []` が log なしで return しているため何が返却されているか不明。 `earthdata_fetch` の Bearer 経路 (L92-95 of `earthdata_auth.py`) は `if resp.status == 200: return 200, text` と HTML check 無しで本文 (HTML or empty も含む) をそのまま返す設計。 LAADS OPeNDAP `.ascii` endpoint が Bearer token に対し HTTP 200 + HTML body (login page or error page) を返す仕様変更を疑っている。

## What

`fetch_cloud_day` の silent return path を `logger.warning` 付きに分割。 per-run 5 件 cap (`_diag_silent` 関数属性) で log 暴発を防止 (`_resolve_filename` の per-year 3 件 cap precedent と同型)。

- empty body → `Cloud %s: HTTP 200 empty body (silent failure)`
- HTML body → `Cloud %s: HTTP 200 HTML body (auth/redirect issue) len=%d preview=%r`

logic preservation: 両ケースとも従来通り `return []` で次 date へ。 通常 ascii は変更なく `_parse_cloud_ascii` へ。

## Scope

- diagnostic logging のみ、 副作用ゼロ
- 同 repo の他 fetcher script (fetch_so2_column.py 等) も同じ silent return パターンの可能性あり、 本 PR は cloud_fraction のみ scope
- 真因判明後の fetcher 修正は別 PR

## Verify

- caller diff: +18 / -1 / single file (`scripts/fetch_cloud_fraction.py`)
- Opus subagent review APPROVE (7 観点全 ✅): indent 整合 / logic preservation / diag counter 設計 / 副作用ゼロ / 線形コスト 全 OK
- 軽微 nit: empty/HTML counter 分離は別 PR 可

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and diagnostics for cloud data retrieval operations. The system now provides clearer diagnostic warnings when encountering empty responses or authentication/redirect issues, enabling better troubleshooting and operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->