### PR TITLE
fix(backfill): checkpoint restore timeout 180→600 + snapshot VACUUM

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -214,7 +214,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 180 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -344,6 +344,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
+              dst.execute("VACUUM")
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -501,7 +502,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 180 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -649,6 +650,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
+              dst.execute("VACUUM")
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -806,7 +808,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 180 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -1111,7 +1113,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 180 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -1295,6 +1297,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
+              dst.execute("VACUUM")
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -1450,7 +1453,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 180 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -1608,6 +1611,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
+              dst.execute("VACUUM")
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -1801,7 +1805,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 180 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -2255,6 +2259,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
+              dst.execute("VACUUM")
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -344,7 +344,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
-              dst.execute("VACUUM")
+              dst.execute('VACUUM')
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -650,7 +650,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
-              dst.execute("VACUUM")
+              dst.execute('VACUUM')
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -1297,7 +1297,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
-              dst.execute("VACUUM")
+              dst.execute('VACUUM')
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -1611,7 +1611,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
-              dst.execute("VACUUM")
+              dst.execute('VACUUM')
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')
@@ -2259,7 +2259,7 @@ jobs:
               # 'database disk image is malformed' on read (root cause of
               # 2026-05-08 schedule cron Tree 98196 corruption).
               dst.execute('PRAGMA journal_mode = DELETE')
-              dst.execute("VACUUM")
+              dst.execute('VACUUM')
               dst.close()
               src.close()
               rm_sidefiles('data/geohazard_snapshot.db')


### PR DESCRIPTION
## Problem

PR #143 effect measurement run **25590448050** (5/9 04:37Z) fell back to checkpoint **25574831633** (5/8 19:19Z **pre-fix-f12fc20**) after 2 newer attempts both failed:

```
[04:38:52] trying artifact: backfill-checkpoint-25588837440 → 8m07s 後諦め
[04:46:59] trying artifact: backfill-checkpoint-25581317414 → 7m38s 後諦め
[04:54:37] trying artifact: backfill-checkpoint-25574831633 → 1m41s で復元成功
```

This means **all backfill progress between 5/8 19:19Z and 5/9 04:37Z was wasted**, and the 2 cron-2 BQ verification confirmed iss_lis row count stayed at 1543 (= 1 cron 1 result, no new progress).

## Root cause

1. **`timeout 180` per artifact attempt** is too tight: post-fix-f12fc20 snapshot DBs are ~2.14 GB (Artifact ID 6892725739, size 2144848871 bytes). 3 min download budget is exceeded → next-run restore can never use the most-recent checkpoint, falls back to oldest available pre-fix snapshot.

2. **`src.backup(dst)` copies all pages including freed ones**. Without `VACUUM` the snapshot stays at full DB size, exacerbating issue 1.

## Fix (option C, 両方)

- **Restore timeout 180 → 600** across **6** artifact-fetch sites (light + 5 fetch jobs).
- **VACUUM after `PRAGMA journal_mode = DELETE`** in **5 snapshot blocks** (light + 4 fetch jobs) to compact `src.backup()` output.

```python
dst.execute('PRAGMA journal_mode = DELETE')
dst.execute("VACUUM")     # ← 追加
dst.close()
```

Cloud subprocess snapshot (line 935) untouched — separate path with currently-flaky 600s timeout, deferred to follow-up PR.

## Validation plan

- Push → CI green
- Manual smoke dispatch (target=iss_lis) to confirm:
  1. Snapshot completes (VACUUM does not break the integrity check)
  2. Restore step on next cron successfully retrieves `backfill-checkpoint-<this-run-id>` within 600s
  3. Artifact size after VACUUM (expect <2 GB)
- BQ verify iss_lis row_count > 1543

If smoke green, squash merge. Recovery ETA back on track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased timeout for downloading prior workflow artifacts to reduce interruptions in background data processing.
  * Added a database maintenance step during snapshot/backfill operations to improve performance and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/147)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->