### PR TITLE
chore(ci): temporarily disable schedule cron for PR #147 smoke test

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -33,15 +33,15 @@ name: Backfill Data
 # Disable this workflow once coverage reaches 100%.
 
 on:
-  schedule:
-    - cron: '0 0 * * *'    # UTC 00:00 = JST 09:00
-    - cron: '0 3 * * *'    # UTC 03:00 = JST 12:00
-    - cron: '0 6 * * *'    # UTC 06:00 = JST 15:00
-    - cron: '0 9 * * *'    # UTC 09:00 = JST 18:00
-    - cron: '0 12 * * *'   # UTC 12:00 = JST 21:00
-    - cron: '0 15 * * *'   # UTC 15:00 = JST 00:00
-    - cron: '0 18 * * *'   # UTC 18:00 = JST 03:00
-    - cron: '0 21 * * *'   # UTC 21:00 = JST 06:00
+#   schedule:
+#     - cron: '0 0 * * *'    # UTC 00:00 = JST 09:00
+#     - cron: '0 3 * * *'    # UTC 03:00 = JST 12:00
+#     - cron: '0 6 * * *'    # UTC 06:00 = JST 15:00
+#     - cron: '0 9 * * *'    # UTC 09:00 = JST 18:00
+#     - cron: '0 12 * * *'   # UTC 12:00 = JST 21:00
+#     - cron: '0 15 * * *'   # UTC 15:00 = JST 00:00
+#     - cron: '0 18 * * *'   # UTC 18:00 = JST 03:00
+#     - cron: '0 21 * * *'   # UTC 21:00 = JST 06:00
   workflow_dispatch:
     inputs:
       memo:


### PR DESCRIPTION
## Why

Schedule cron is winning the concurrency-group queued slot and cancelling workflow_dispatch runs before they start (run 25599920825 cancelled at 12:52Z by schedule trigger 25601598513).

PR #147 (checkpoint timeout 180->600 + snapshot VACUUM, fix `a76af5e`) cannot be smoke-verified while schedule keeps stealing the slot.

## Plan

1. Merge this PR (schedule OFF)
2. Cancel in-progress run 25601598513 (frees concurrency slot)
3. workflow_dispatch on PR #147 branch (re-smoke 25599920825 succession)
4. Verify VACUUM + timeout 600 work
5. Merge PR #147
6. Open follow-up PR to restore schedule cron

## Risk

Schedule will not fire for ~30-60 min during smoke verification. backfill is incremental and the next schedule cron will catch up (PR #143 checkpoint resume already validated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Disabled automatic scheduled backfill process; manual triggering is now required to initiate backfill operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/149)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->