### PR TITLE
chore(ci): restore schedule cron after PR #147 merge

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -33,15 +33,15 @@ name: Backfill Data
 # Disable this workflow once coverage reaches 100%.
 
 on:
-#   schedule:
-#     - cron: '0 0 * * *'    # UTC 00:00 = JST 09:00
-#     - cron: '0 3 * * *'    # UTC 03:00 = JST 12:00
-#     - cron: '0 6 * * *'    # UTC 06:00 = JST 15:00
-#     - cron: '0 9 * * *'    # UTC 09:00 = JST 18:00
-#     - cron: '0 12 * * *'   # UTC 12:00 = JST 21:00
-#     - cron: '0 15 * * *'   # UTC 15:00 = JST 00:00
-#     - cron: '0 18 * * *'   # UTC 18:00 = JST 03:00
-#     - cron: '0 21 * * *'   # UTC 21:00 = JST 06:00
+  schedule:
+    - cron: '0 0 * * *'    # UTC 00:00 = JST 09:00
+    - cron: '0 3 * * *'    # UTC 03:00 = JST 12:00
+    - cron: '0 6 * * *'    # UTC 06:00 = JST 15:00
+    - cron: '0 9 * * *'    # UTC 09:00 = JST 18:00
+    - cron: '0 12 * * *'   # UTC 12:00 = JST 21:00
+    - cron: '0 15 * * *'   # UTC 15:00 = JST 00:00
+    - cron: '0 18 * * *'   # UTC 18:00 = JST 03:00
+    - cron: '0 21 * * *'   # UTC 21:00 = JST 06:00
   workflow_dispatch:
     inputs:
       memo:


### PR DESCRIPTION
## Why

PR #149 disabled schedule cron temporarily so that PR #147 (checkpoint timeout 180->600 + snapshot VACUUM) could be smoke-verified via workflow_dispatch without concurrency-group competition.

PR #147 squash merged (57146ce, 21:08Z) after re-smoke run **25603689148** completed with all 7 jobs success:

- fetch-hinet **Restore checkpoint** step succeeded in 20:06 (timeout 600 effective on ~2.14 GB post-fix snapshot)
- fetch-hinet **Snapshot DB** step succeeded in 12:21 (VACUUM single-quote fix a76af5e works -- v1 had name VACUUM is not defined)
- merge job success

## Change

Restore the 8 schedule cron lines (3-hour interval) to resume periodic backfill.

## Impact

Next schedule cron will fire at the next 3-hour boundary. The new run will use master HEAD (= PR #147 + this restore) and pull the latest checkpoint artifact via timeout 600 within the same concurrency group as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled scheduled automated backfill operations to run at regular intervals throughout the day, ensuring data consistency and timeliness without manual intervention.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/151)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->