### PR TITLE
fix(backfill): extend Upload to BigQuery timeout 30->60 min

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2493,7 +2493,7 @@ jobs:
               || inputs.target == 'all'
               || inputs.target == '')
         continue-on-error: true
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Problem

The `Upload to BigQuery` step in the `merge` job has `timeout-minutes: 30`, which became insufficient as the `ioc_sea_level` table grew naturally over time. The step is now timing out before reaching the tables that come after `ioc_sea_level` in the streaming order, leaving them stale in BigQuery.

### Evidence

Two consecutive cron runs hit the 30-minute timeout exactly during `ioc_sea_level` upload:

- cron [25626191594](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25626191594/job/75236276093) (post-PR-#153, conclusion=failure due to other unrelated issues): `##[error]The action 'Upload to BigQuery' has timed out after 30 minutes.`
- cron [25629509525](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25629509525/job/75246696951) (post-PR-#153, conclusion=success): same `##[error]` at 18:41:14Z.

### Root cause

This is **not** a regression introduced by PR #153. PR #153 only changed `Restore` step timeouts; the BQ upload step is unrelated. What happened is that `ioc_sea_level` grew naturally:

| run | sha | ioc_sea_level rows | BQ upload step duration | result |
|---|---|---|---|---|
| 25623486360 | b03055593 (pre-#153) | 46,986,221 | 29:37 (started 11:40:54Z, completed 12:10:31Z) | success — finished with **23 seconds to spare** before the 30-min timeout |
| 25626191594 | ab67bd09 (post-#153) | 50,693,377 | exceeded 30 min during ioc_sea_level upload (15:33:21Z) | step killed — waveform tables not reached |
| 25629509525 | 9036b028 (post-#153) | 50,693,377 | exceeded 30 min (18:41:14Z) | step killed — same |

Pre-#153 was passing the 30-minute limit by a thin margin. The +3.7M rows growth (+7.9%) of `ioc_sea_level` is enough to tip it over. The streaming order in `scripts/load_raw_to_bq.py` places `hinet_waveform`, `snet_waveform`, `fnet_waveform`, `swarm_em` **after** `ioc_sea_level`, so when the step is killed during ioc_sea_level upload, those four tables are skipped entirely.

### Impact

`ioc_sea_level` itself still completes (BQ load jobs are async — the load job is submitted before the GH Actions step is killed and continues to completion on Google's side, leaving `last_modified_time` correct). The four tables that come after, however, are stale:

| table | merged DB rows | BQ rows | drift |
|---|---|---|---|
| snet_waveform | 79,962 | 72,996 | +6,966 unreflected |
| fnet_waveform | 5,108 | 4,636 | +472 unreflected |
| hinet_waveform | 9,097 | 8,343 | +754 unreflected |
| swarm_em | 4,903 | 4,903 | in sync (no fetch this cycle) |

The merged DB and the `checkpoint` artifact are correct, so the data is preserved and will be carried forward to the next cycle. Only BigQuery is stale, and the drift accumulates each cycle until fixed.

## Fix

Extend the `Upload to BigQuery` step timeout from 30 to 60 minutes in `.github/workflows/backfill.yml`. One-line change, no logic touched:

```diff
         continue-on-error: true
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
```

60 minutes gives ~2x headroom over the observed pre-#153 duration (29:37). It also matches the convention adopted by PR #153 (which extended the Restore step from 25 to 60 minutes). If `ioc_sea_level` continues to grow we can revisit, but 60 minutes is comfortable for current scale.

## Test plan

- [ ] After merge, watch the next scheduled cron run for: BQ upload step completes without `##[error]The action 'Upload to BigQuery' has timed out` annotation
- [ ] Verify `last_modified_time` for `hinet_waveform`, `snet_waveform`, `fnet_waveform`, `swarm_em` is updated to the run's BQ upload window (not the stale 12:10Z timestamp from cron 25623486360)
- [ ] Confirm row counts in BQ match the merged DB values (e.g., `hinet_waveform = 9,097`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration to improve system reliability during data processing operations.

**Note:** This release contains only internal infrastructure improvements with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->