### PR TITLE
refactor: drop BigQuery upload steps from workflows (Phase 1)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1088,22 +1088,6 @@ jobs:
           retention-days: 90
           if-no-files-found: warn
 
-      - name: Load feature matrix to BigQuery
-        if: always()
-        continue-on-error: true
-        timeout-minutes: 15
-        env:
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          PHASE: "${{ github.sha }}"
-          RESULTS_DIR: ./results
-        run: |
-          pip install google-cloud-bigquery pandas db-dtypes pyarrow 2>/dev/null
-          if [ -f results/feature_matrix.json ]; then
-            python3 scripts/load_to_bq.py
-          else
-            echo "No feature_matrix.json — skipping BQ load"
-          fi
-
       - name: Run prospective prediction analysis
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2480,30 +2480,6 @@ jobs:
           path: data/geohazard.db
           retention-days: 30
 
-      - name: Upload to BigQuery
-        id: bq_upload
-        # Skip when snapshot's integrity check rejected the DB, or when this
-        # is a targeted dispatch -- load_raw_to_bq.py uses WRITE_TRUNCATE for
-        # all 31 tables, so a targeted run would overwrite BQ with older
-        # rows for non-target tables (exactly what bit lightning_thunder_hour
-        # 31,824 -> 24,480 on 2026-04-17).
-        if: >-
-          steps.snapshot.outcome == 'success'
-          && (github.event_name != 'workflow_dispatch'
-              || inputs.target == 'all'
-              || inputs.target == '')
-        continue-on-error: true
-        timeout-minutes: 60
-        env:
-          GEOHAZARD_DB_PATH: ./data/geohazard.db
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
-          # Repository Variable: set to 'true' during initial recovery period
-          # to bypass regression guard (otherwise still-recovering tables would
-          # be locked out of BQ updates). Unset / set to 'false' once tables
-          # are back to baseline so the guard can catch future incidents.
-          BQ_FORCE_OVERWRITE: ${{ vars.BQ_FORCE_OVERWRITE }}
-        run: python3 scripts/load_raw_to_bq.py
-
       - name: Notify Discord
         if: always()
         continue-on-error: true
@@ -2542,7 +2518,6 @@ jobs:
           FETCH_DART: ${{ needs.light.outputs.fetch_dart }}
           FETCH_IOC_SEALEVEL: ${{ needs.light.outputs.fetch_ioc_sealevel }}
           FETCH_IOC_DART: ${{ needs.light.outputs.fetch_ioc_dart }}
-          BQ_UPLOAD: ${{ steps.bq_upload.outcome }}
           MERGE_OUTCOME: ${{ steps.merge.outcome }}
           FETCH_MODIS_RESULT: ${{ needs.fetch-modis.result }}
           FETCH_SO2_RESULT: ${{ needs.fetch-so2.result }}
@@ -2688,7 +2663,6 @@ jobs:
               'Particle flux': os.environ.get('FETCH_PARTICLE_FLUX', 'skipped'),
               'DART': os.environ.get('FETCH_DART', 'skipped'),
               'IOC sea level': os.environ.get('FETCH_IOC_SEALEVEL', 'skipped'),
-              'BQ upload': os.environ.get('BQ_UPLOAD', 'skipped'),
               'Restore modis': os.environ.get('RESTORE_MODIS', 'skipped'),
               'Restore so2': os.environ.get('RESTORE_SO2', 'skipped'),
               'Restore cloud': os.environ.get('RESTORE_CLOUD', 'skipped'),
@@ -2809,7 +2783,6 @@ jobs:
             needs.light.outputs.fetch_dart == 'failure' ||
             needs.light.outputs.fetch_ioc_sealevel == 'failure' ||
             needs.light.outputs.fetch_ioc_dart == 'failure' ||
-            steps.bq_upload.outcome == 'failure' ||
             steps.merge.outcome == 'failure'
           )
         env:
@@ -2848,7 +2821,6 @@ jobs:
           [ "${{ needs.light.outputs.fetch_dart }}" = "failure" ] && FAILED="$FAILED dart"
           [ "${{ needs.light.outputs.fetch_ioc_sealevel }}" = "failure" ] && FAILED="$FAILED ioc_sealevel"
           [ "${{ needs.light.outputs.fetch_ioc_dart }}" = "failure" ] && FAILED="$FAILED ioc_dart"
-          [ "${{ steps.bq_upload.outcome }}" = "failure" ] && FAILED="$FAILED bq_upload"
           [ "${{ steps.merge.outcome }}" = "failure" ] && FAILED="$FAILED merge"
           FAILED=$(echo "$FAILED" | xargs)
 


### PR DESCRIPTION
## Problem

BQ Sandbox free tier is **10 GB storage cap**. The geohazard dataset is already at **9.80 GB** (98%) and growing — `ioc_sea_level` alone added 3.7M rows (+7.9%) in the last few days, and the 4 waveform tables continue to grow per cron cycle. Beyond 10 GB, BQ moves to active storage billing ($0.044/GB/month).

Audit of how the codebase uses BQ:

| script / workflow | direction | role |
|---|---|---|
| `scripts/load_raw_to_bq.py` (664 lines) | WRITE | 31 raw tables → BQ streaming |
| `scripts/load_to_bq.py` (204 lines) | WRITE | `feature_matrix` + metadata + nonzero_rates → BQ |
| `scripts/smoke_test_bq_regression_guard.py` | test | regression guard smoke test |
| `scripts/cleanup_ioc_sealevel_dart.py` | WRITE | one-off cleanup helper |
| `.github/workflows/backfill.yml` | WRITE | `Upload to BigQuery` step (id `bq_upload`) — hot path |
| `.github/workflows/analysis.yml` | WRITE | `Load feature matrix to BigQuery` step |

`grep -rln 'bigquery.Client' scripts/ src/` shows **only the 2 write scripts**. `grep -rln 'SELECT.*FROM.*geohazard\.'` returns zero matches. **The codebase has no BQ READ path** — BQ is currently a write-only archive without active consumers.

Externally, the BQ tables aren't wired to Looker Studio / Connected Sheets / Colab BigQuery extensions either in this project's workflow. Ad-hoc inspection via `bq query` could continue against historical data while the dataset auto-expires.

## Fix

Remove the two `Upload to BigQuery` / `Load feature matrix to BigQuery` workflow steps and their dependent references. Scripts retained in `scripts/` for posterity and possible re-enable.

### `.github/workflows/backfill.yml` (-28 lines, no additions)
- Delete `Upload to BigQuery` step block (24 lines: step name, id `bq_upload`, comment, `if:` guard, `continue-on-error`, `timeout-minutes: 60`, env block, run command, trailing blank).
- Delete 4 dependent references:
  - `BQ_UPLOAD: ${{ steps.bq_upload.outcome }}` env in Discord notify step.
  - `'BQ upload': os.environ.get('BQ_UPLOAD', 'skipped'),` entry in Discord step results dict.
  - `steps.bq_upload.outcome == 'failure' ||` line in Issue auto-create condition.
  - `[ "${{ steps.bq_upload.outcome }}" = "failure" ] && FAILED="$FAILED bq_upload"` in failure summary builder.

### `.github/workflows/analysis.yml` (-16 lines, no additions)
- Delete `Load feature matrix to BigQuery` step block (already `continue-on-error: true`, no downstream consumer; the subsequent `Run prospective prediction analysis` step reads `GEOHAZARD_DB_PATH` SQLite, not BQ).

Total: **44 deletions across 2 files, zero modifications, zero additions**. Surgical scope.

## Effects

- **BQ free tier pressure**: 9.80 / 10 GB → no further writes; existing dataset preserved, auto-expires under Sandbox 60-day no-access rule, or can be manually dropped later.
- **CI time savings**: `Upload to BigQuery` step ran 30–60 min per merge job × 8 cron/day = **4–8 hours of GHA minutes saved per day**.
- **Data persistence path**: GH Actions artifacts (30-day retention) remain authoritative source; follow-up PR planned to add **RPi5 SSD mirror** via systemd timer (205 GB free, 20× headroom over BQ free tier) for long-term storage.

## Test plan

- [ ] Workflow yaml parses cleanly (CodeRabbit / GitHub Actions validator).
- [ ] Next scheduled cron after merge: `merge` job completes without `bq_upload` step orphan reference errors; Discord notify body shows no `BQ upload: skipped` row, and Issue auto-create condition still triggers correctly on real fetch failures.
- [ ] `analysis.yml` run: `Run prospective prediction analysis` step still executes (does not depend on the removed BQ step).

## Rollback

Revert the commit and the `Upload to BigQuery` step returns. Underlying scripts (`load_raw_to_bq.py` etc.) remain in `scripts/` so no code restoration needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed BigQuery upload steps from CI/CD workflows. Analysis workflow no longer uploads feature matrix results to BigQuery. Backfill workflow no longer uploads database checkpoints following merge operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/156)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->