### PR TITLE
refactor(merge): run merge job on RPi5 self-hosted runner + SSD mirror

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2306,29 +2306,22 @@ jobs:
 
   # =====================================================================
   # MERGE JOB -- combine light (base) with modis / so2 / cloud / snet
-  # overlays, then snapshot / coverage / checkpoint / BQ / Discord / Issue.
-  # if: always() so single-job failure still triggers BQ upload + reporting.
+  # overlays, then snapshot / SSD mirror / coverage / checkpoint / Discord.
+  # Runs on RPi5 self-hosted runner so the merged DB lands on the ext4 SSD
+  # as primary storage. if: always() so single-job failure still reports.
   # =====================================================================
   merge:
     needs: [fetch-modis, fetch-so2, fetch-cloud, fetch-snet, fetch-hinet, light]
     if: always() && inputs.target != 'diagnostic'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ARM64, rpi5-geohazard]
     # Bumped 60->150 after Hi-net Stage 1 (PR #127) pushed merge time past
     # 60min ceiling (run 25276071313 / 25279499629 both cancelled at Snapshot
     # step). 150min matches fetch-snet/fetch-hinet/light heavy-job tier with
-    # comfortable headroom for 25min BQ upload + 10min merge + ~5min misc.
+    # comfortable headroom for ~10min merge + ~5min misc + SSD copy.
     timeout-minutes: 150
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: |
-          pip install google-cloud-bigquery pyarrow numpy
 
       - name: Download light.db artifact
         id: download_light
@@ -2424,6 +2417,18 @@ jobs:
               print(f'wal_checkpoint failed: {e}')
               sys.exit(1)
           "
+
+      - name: Mirror merged DB to RPi5 SSD (primary storage)
+        if: steps.snapshot.outcome == 'success'
+        # Atomic-swap: stage to .new, retain previous as .prev (silenced on
+        # first run when no current file exists), then mv -f for atomic
+        # POSIX rename. SSD has 205GB free for the geohazard archive.
+        run: |
+          mkdir -p /mnt/ssd/geohazard
+          cp data/geohazard.db /mnt/ssd/geohazard/geohazard.db.new
+          cp /mnt/ssd/geohazard/geohazard.db /mnt/ssd/geohazard/geohazard.db.prev 2>/dev/null || true
+          mv -f /mnt/ssd/geohazard/geohazard.db.new /mnt/ssd/geohazard/geohazard.db
+          ls -lh /mnt/ssd/geohazard/
 
       - name: Coverage report
         if: steps.snapshot.outcome == 'success'

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2430,12 +2430,18 @@ jobs:
         # Same gating as `Upload checkpoint artifact` below: never overwrite
         # the SSD primary copy from a targeted workflow_dispatch (e.g.
         # target=cloud) because that DB only contains fresh rows for one
-        # table and would roll back the other tables' state.
+        # table and would roll back the other tables' state. The
+        # `github.ref == 'refs/heads/master'` clause additionally prevents
+        # a feature-branch workflow_dispatch (target=all or '') from
+        # overwriting the SSD primary; only master should write to it.
+        # `schedule` events always run on the default branch in GitHub
+        # Actions, so this clause does not block the production cron.
         # Atomic-swap: stage to .new, retain previous as .prev (silenced on
         # first run when no current file exists), then mv -f for atomic
         # POSIX rename. SSD has 205GB free for the geohazard archive.
         if: >-
           steps.snapshot.outcome == 'success'
+          && github.ref == 'refs/heads/master'
           && (github.event_name != 'workflow_dispatch'
               || inputs.target == 'all'
               || inputs.target == '')
@@ -2490,8 +2496,15 @@ jobs:
         # checkpoint is missing data from other tables that were accumulated
         # in previous full runs. Uploading would overwrite the latest full
         # checkpoint and reset progress for all other tables.
+        # The `github.ref == 'refs/heads/master'` clause additionally
+        # prevents a feature-branch workflow_dispatch (target=all or '')
+        # from overwriting the canonical checkpoint artifact lineage; only
+        # master cron / master manual dispatch should advance the
+        # checkpoint. `schedule` always runs on the default branch so this
+        # does not block the production pipeline.
         if: >-
           steps.snapshot.outcome == 'success'
+          && github.ref == 'refs/heads/master'
           && (github.event_name != 'workflow_dispatch'
               || inputs.target == 'all'
               || inputs.target == '')

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2419,10 +2419,18 @@ jobs:
           "
 
       - name: Mirror merged DB to RPi5 SSD (primary storage)
-        if: steps.snapshot.outcome == 'success'
+        # Same gating as `Upload checkpoint artifact` below: never overwrite
+        # the SSD primary copy from a targeted workflow_dispatch (e.g.
+        # target=cloud) because that DB only contains fresh rows for one
+        # table and would roll back the other tables' state.
         # Atomic-swap: stage to .new, retain previous as .prev (silenced on
         # first run when no current file exists), then mv -f for atomic
         # POSIX rename. SSD has 205GB free for the geohazard archive.
+        if: >-
+          steps.snapshot.outcome == 'success'
+          && (github.event_name != 'workflow_dispatch'
+              || inputs.target == 'all'
+              || inputs.target == '')
         run: |
           mkdir -p /mnt/ssd/geohazard
           cp data/geohazard.db /mnt/ssd/geohazard/geohazard.db.new

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -102,8 +102,16 @@ permissions:
 # light restore step hanging when a prior run overlapped). cancel-in-progress
 # is deliberately false so a long-running run isn't killed by the next
 # schedule tick; the next run queues until this one finishes.
+# Scope: schedule (master cron) shares one queue ("backfill-data-master")
+# to serialise the production pipeline. workflow_dispatch on a feature
+# branch gets its own ref-scoped queue so PR smoke runs don't fight the
+# master cron (2026-05-11: PR #157 smoke was evicted by a fresh schedule
+# tick before this change). Data isolation between branch dispatches and
+# master is already enforced by the SSD-mirror / artifact-upload gates
+# below, so the only thing the shared queue was protecting was the
+# artifact API, and the schedule-only sub-queue is sufficient for that.
 concurrency:
-  group: backfill-data
+  group: backfill-data-${{ github.event_name == 'schedule' && 'master' || github.ref }}
   cancel-in-progress: false
 
 # Reusable shell snippets are inlined per job below; YAML anchors aren't


### PR DESCRIPTION
## Problem

After PR #156 removed the `Upload to BigQuery` step (because the Sandbox 10 GB cap was 98 % full and the codebase has zero BQ READ paths), the only persisted copy of the merged `geohazard.db` is the GH Actions checkpoint artifact (30-day rolling retention). That artifact tier alone is acceptable as a backup but not as the long-term archive.

We have an RPi5 with an ext4 SSD mounted at `/mnt/ssd` with **205 GB free** — that is 20 × the BQ free-tier cap. Phase 2 of the BQ retirement plan is to move the merged DB onto that SSD as the primary persistence tier, while keeping the artifact as a 30-day backup.

## Fix

Run the `merge` job on a self-hosted GH Actions runner that lives on the RPi5 itself, and add an explicit `Mirror merged DB to RPi5 SSD` step. The merged DB lands on `/mnt/ssd/geohazard/geohazard.db` directly — no separate cron / push / mirror plumbing required.

### `.github/workflows/backfill.yml`

| change | rationale |
|---|---|
| `runs-on: ubuntu-latest` → `runs-on: [self-hosted, Linux, ARM64, rpi5-geohazard]` | Run the merge job on the RPi5 itself so the SSD copy is a local `cp` rather than an extra network round-trip from `ubuntu-latest`. Uses runner labels matching the registered runner. |
| **Removed** `actions/setup-python@v5` step | RPi5 has system `/usr/bin/python3` (3.11.2). The merge job uses only `sqlite3` stdlib and `scripts/merge_checkpoints.py` which imports only `argparse / os / shutil / sqlite3 / sys` (stdlib). No version pin needed. |
| **Removed** `Install dependencies` step (`pip install google-cloud-bigquery pyarrow numpy`) | All three packages were BQ-side dependencies. With BQ upload gone, none are imported by anything the merge job executes. |
| **Added** `Mirror merged DB to RPi5 SSD (primary storage)` step | Atomic-swap pattern; same gating as `Upload checkpoint artifact` (skip on targeted dispatch to avoid rolling back tables that didn't refetch this run). |
| Updated stale BQ-referencing comments above the merge job and the `timeout-minutes: 150` rationale | Comment-only; was lying after #156. |

### `Mirror merged DB to RPi5 SSD` step body

```yaml
- name: Mirror merged DB to RPi5 SSD (primary storage)
  # Same gating as `Upload checkpoint artifact` below: never overwrite
  # the SSD primary copy from a targeted workflow_dispatch (e.g.
  # target=cloud) because that DB only contains fresh rows for one
  # table and would roll back the other tables' state.
  # Atomic-swap: stage to .new, retain previous as .prev (silenced on
  # first run when no current file exists), then mv -f for atomic
  # POSIX rename. SSD has 205GB free for the geohazard archive.
  if: >-
    steps.snapshot.outcome == 'success'
    && (github.event_name != 'workflow_dispatch'
        || inputs.target == 'all'
        || inputs.target == '')
  run: |
    mkdir -p /mnt/ssd/geohazard
    cp data/geohazard.db /mnt/ssd/geohazard/geohazard.db.new
    cp /mnt/ssd/geohazard/geohazard.db /mnt/ssd/geohazard/geohazard.db.prev 2>/dev/null || true
    mv -f /mnt/ssd/geohazard/geohazard.db.new /mnt/ssd/geohazard/geohazard.db
    ls -lh /mnt/ssd/geohazard/
```

### Runner setup (already done, out of band)

- Extracted `actions-runner-linux-arm64-2.332.0.tar.gz` to `/home/yasu/actions-runner-geohazard/` on RPi5 (reused existing tarball at `/home/yasu/actions-runner/`).
- `./config.sh --url https://github.com/yasumorishima/japan-geohazard-monitor --name rpi5-geohazard --labels rpi5-geohazard --work _work --unattended --replace`.
- `sudo ./svc.sh install yasu && sudo ./svc.sh start` → `actions.runner.yasumorishima-japan-geohazard-monitor.rpi5-geohazard.service` `Active: active (running)`.
- `gh api repos/yasumorishima/japan-geohazard-monitor/actions/runners` confirms the runner is `status: online`, labels `[self-hosted, Linux, ARM64, rpi5-geohazard]`, `busy: false`.

### Backup tier preserved

`Upload checkpoint artifact` step is **unchanged** — the artifact (30-day retention) remains as a secondary copy in case the SSD is unavailable or corrupted.

## Effects

- Primary persistence tier becomes the RPi5 SSD (`/mnt/ssd/geohazard/geohazard.db`), 205 GB free vs BQ's 10 GB cap.
- Merge job runs on RPi5 hardware. fetch-* and analysis jobs continue on `ubuntu-latest`; only `merge` is moved.
- No new secrets, no Tailscale push plumbing, no PAT. The runner's own long-lived handshake handles auth.
- pip install + setup-python dropped from the merge job → ~30–60 s saved per cron cycle on those two steps.
- Stale BQ comments cleaned up.

## Out of scope / follow-up

- `pip install ... google-cloud-bigquery pyarrow ...` in **fetch-* and `light` jobs** (6 sites) is also dead weight post-#156 but kept here to avoid scope creep. Separate small PR.
- `scripts/load_raw_to_bq.py` etc. still present in `scripts/` (intentional, per #156 description). No change.
- Lowering `timeout-minutes: 150` after observing real RPi5 merge durations. Needs runtime data first.

## Test plan

- [ ] CodeRabbit pass on the workflow YAML.
- [ ] Manual SSD atomic-swap dry-run on the Pi (throwaway file): verify `cp` + `cp .prev || true` + `mv -f` ordering produces the expected state, including the first-run case where the current file doesn't exist.
- [ ] `workflow_dispatch` smoke with `target: earthquakes` (light's smallest sub-fetcher) → confirm:
  - [ ] `merge` job is picked up by the `rpi5-geohazard` runner (not ubuntu-latest).
  - [ ] `merge_checkpoints.py` succeeds with missing overlays (`light` only, no modis/so2/cloud/snet/hinet artifacts).
  - [ ] `Snapshot merged DB for checkpoint` succeeds.
  - [ ] `Mirror merged DB to RPi5 SSD` step is **correctly skipped** (targeted dispatch gate).
  - [ ] `Upload checkpoint artifact` is also **correctly skipped** (same gate).
- [ ] Post-merge, next scheduled cron (target=all): `Mirror merged DB to RPi5 SSD` fires and `/mnt/ssd/geohazard/geohazard.db` is updated.

## Rollback

Revert the commit. The `merge` job returns to `ubuntu-latest` with `setup-python` + `Install dependencies` restored, and the SSD mirror step is gone. The RPi5 runner stays installed but receives no jobs; can be left running or stopped with `sudo ./svc.sh stop` on the Pi.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow infrastructure by optimizing build execution on specialized hardware and implementing atomic database synchronization to ensure reliable data replication during deployment processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->