### PR TITLE
ops(backfill): merge job downloads to /mnt/ssd/runner-temp instead of SD /tmp

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2337,7 +2337,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-light-${{ github.run_id }}
-          path: /tmp/light
+          path: /mnt/ssd/runner-temp/light
 
       - name: Download modis.db artifact
         id: download_modis
@@ -2345,7 +2345,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-modis-${{ github.run_id }}
-          path: /tmp/modis
+          path: /mnt/ssd/runner-temp/modis
 
       - name: Download so2.db artifact
         id: download_so2
@@ -2353,7 +2353,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-so2-${{ github.run_id }}
-          path: /tmp/so2
+          path: /mnt/ssd/runner-temp/so2
 
       - name: Download cloud.db artifact
         id: download_cloud
@@ -2361,7 +2361,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-cloud-${{ github.run_id }}
-          path: /tmp/cloud
+          path: /mnt/ssd/runner-temp/cloud
 
       - name: Download snet.db artifact
         id: download_snet
@@ -2369,7 +2369,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-snet-${{ github.run_id }}
-          path: /tmp/snet
+          path: /mnt/ssd/runner-temp/snet
 
       - name: Download hinet.db artifact
         if: needs.fetch-hinet.result == 'success'
@@ -2377,7 +2377,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-hinet-${{ github.run_id }}
-          path: /tmp/hinet
+          path: /mnt/ssd/runner-temp/hinet
 
       - name: Merge light + 4 overlays
         id: merge
@@ -2386,13 +2386,13 @@ jobs:
           # --require-base ensures we never let an overlay-only DB through to BQ
           # (would WRITE_TRUNCATE every light-owned table and zero them out).
           python3 scripts/merge_checkpoints.py \
-            --base /tmp/light/geohazard.db \
-            --overlay /tmp/modis/geohazard.db:modis_lst \
-            --overlay /tmp/so2/geohazard.db:so2_column \
-            --overlay /tmp/cloud/geohazard.db:cloud_fraction \
-            --overlay /tmp/snet/geohazard.db:snet_waveform \
-            --overlay /tmp/snet/geohazard.db:fnet_waveform \
-            --overlay /tmp/hinet/geohazard.db:hinet_waveform \
+            --base /mnt/ssd/runner-temp/light/geohazard.db \
+            --overlay /mnt/ssd/runner-temp/modis/geohazard.db:modis_lst \
+            --overlay /mnt/ssd/runner-temp/so2/geohazard.db:so2_column \
+            --overlay /mnt/ssd/runner-temp/cloud/geohazard.db:cloud_fraction \
+            --overlay /mnt/ssd/runner-temp/snet/geohazard.db:snet_waveform \
+            --overlay /mnt/ssd/runner-temp/snet/geohazard.db:fnet_waveform \
+            --overlay /mnt/ssd/runner-temp/hinet/geohazard.db:hinet_waveform \
             --dst data/geohazard.db \
             --require-base
 


### PR DESCRIPTION
## Summary
The merge job runs on `rpi5-geohazard` self-hosted runner (PR #157). Until now its `actions/download-artifact@v4` steps wrote scratch artifacts to `/tmp/<name>` on the RPi5 SD card (58GB, wears with writes). Each cron tick downloads ~10GB total across 6 artifacts (`light` ~1GB, `modis` ~5GB, `so2` ~2GB, `cloud` ~5GB, `snet` ~23MB, `hinet` ~3MB), peaking SD usage and shortening SD-card lifespan.

Route those scratch downloads to `/mnt/ssd/runner-temp/` (USB SSD, 229GB ext4) instead. **13 lines changed in `.github/workflows/backfill.yml`**:
- 6 `path:` parameters in `actions/download-artifact@v4` steps
- 7 `--base` / `--overlay` arguments to `scripts/merge_checkpoints.py`

Other jobs (`fetch-light` / `fetch-modis` / `fetch-so2` / `fetch-cloud` / `fetch-snet` / `fetch-hinet` / diagnostic) run on `ubuntu-latest` and continue to use `/tmp/*` on the GHA-hosted runner — those 72 path references are intentionally unchanged.

## Background
2026-05-12 early morning the RPi5 SD card hit 84% (warning threshold 88%). Investigation showed:
- /tmp on SD card held 11GB of orphan artifacts from cancelled run 25700085326
- Each successful cron tick temporarily spiked SD by 10GB during download → merge → cleanup
- Without this PR, SD card capacity worry would recur every cron tick

After this PR merges:
- Scratch artifacts land on USB SSD (currently 18% used, 179GB free)
- SD card no longer spikes during cron
- SD card wear reduced (USB SSD ext4 handles writes better than SD)

## Test plan
- [ ] CI green (no new tests, workflow-only change)
- [ ] After merge, watch next master cron tick; verify `/mnt/ssd/runner-temp/light/geohazard.db` etc. are created during the merge job
- [ ] Verify merge step succeeds with new paths (light + 4 overlays consumed correctly)
- [ ] Verify SD card stays under 30% during/after cron (was peaking 75%+ before)
- [ ] Verify USB SSD writes increase by ~10GB during cron then return after auto-cleanup at job end

## Pre-flight
- `/mnt/ssd/runner-temp/` already exists on rpi5-geohazard (created during 2026-05-12 SD-rescue session)
- `actions/download-artifact@v4` auto-creates subdirs `light/`, `modis/`, etc. under the given path
- Path change is internal to merge job; downstream `Mirror merged DB to RPi5 SSD` step (writes to `/mnt/ssd/geohazard/geohazard.db`) is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline artifact storage locations and related configuration references for improved infrastructure efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->