### PR TITLE
docs(readme): note merge job scratch artifacts now on /mnt/ssd/runner-temp (PR #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,7 +1273,7 @@ Feature matrix exported to Google Drive for Colab GPU experiments. (Historical: 
 | **PINN** | 📋 Next | Physics-Informed NN with Rate-State friction loss (Nature Comms 2023) |
 | **Phase 19** | 🔄 Running | S-netマルチセンサー（0120速度+0120C高感度+0120A加速度）+ VLFスペクトル。84→92特徴量。ワークフロー修正: S-net前半移動+incremental save（タイムアウト時データ喪失防止）+SMAP無効化 |
 | **S-net** | ✅ Active | NIED承認済。圧力チャンネル不在→**波形特徴量**に転換。0120A(加速度)確認済み、0120(速度)+0120C(高感度)をPhase 19で追加 |
-| **Data Backfill** | 🔄 Running | `backfill.yml`: 全28+ fetcher を3時間毎cron（8スケジュール、24/7）で実行。 merge job が結果を **RPi5 SSD (`/mnt/ssd/geohazard/geohazard.db`, 205 GB free)** に一次保存 (PR #157)、 GH Actions checkpoint artifact (30-day) は backup tier。 Discord通知（coverage %） + 失敗時Issue自動作成。 100%到達でcron頻度削減 |
+| **Data Backfill** | 🔄 Running | `backfill.yml`: 全28+ fetcher を3時間毎cron（8スケジュール、24/7）で実行。 merge job が結果を **RPi5 SSD (`/mnt/ssd/geohazard/geohazard.db`, 205 GB free)** に一次保存 (PR #157)、 merge 中の scratch artifacts (light/modis/so2/cloud/snet/hinet) も `/mnt/ssd/runner-temp/` (USB SSD) に展開して SD card 摩耗回避 (PR #159、 2026-05-12)、 GH Actions checkpoint artifact (30-day) は backup tier。 Discord通知（coverage %） + 失敗時Issue自動作成。 100%到達でcron頻度削減 |
 
 ### Persistence Tiers
 
@@ -1282,6 +1282,7 @@ Feature matrix exported to Google Drive for Colab GPU experiments. (Historical: 
 | 階層 | 場所 | 役割 | 容量 | 保持 |
 |---|---|---|---|---|
 | Primary | **RPi5 ext4 SSD** `/mnt/ssd/geohazard/geohazard.db` | merge job 直接書き出し (PR #157、 RPi5 self-hosted runner) | 205 GB free | 永続 (`.prev` で 1 世代ロールバック保持) |
+| Scratch (during merge) | **RPi5 ext4 SSD** `/mnt/ssd/runner-temp/{light,modis,so2,cloud,snet,hinet}/geohazard.db` | actions/download-artifact@v4 が job 中に展開 (PR #159、 2026-05-12) | ~10 GB peak / cron tick | 一時 (次 cron tick で上書き) |
 | Backup | **GH Actions artifact** `backfill-checkpoint-<run_id>` | merge job が常時 upload | 30 GB cap | 30 day rolling |
 
 > targeted `workflow_dispatch` (`target != 'all'`) では一次・二次とも上書き skip (該当 run が部分テーブルしか更新しないため、 他テーブルの状態を巻き戻すのを防ぐ)。


### PR DESCRIPTION
## Summary
PR #159 (2026-05-12 merge) moved the merge job download-artifact scratch from RPi5 SD `/tmp` to USB SSD `/mnt/ssd/runner-temp`. README mentioned the primary persistence move (PR #157) but had no reference to the scratch location migration.

## Changes
- `Data Backfill` table row: inline note about scratch artifacts on `/mnt/ssd/runner-temp/` (PR #159)
- `Persistence Tiers` table: new `Scratch (during merge)` row under `Primary`, documenting ~10 GB peak per cron tick and overwrite-on-next-tick lifecycle

No code change; documentation-only follow-up to PR #159.

## Test plan
- [x] Visual diff review (2 insertions, 1 deletion)
- [ ] After merge, verify rendered README on GitHub shows both updates correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data backfill workflow documentation to clarify storage tier specifications, including primary SSD storage paths and scratch artifact handling for merge operations.
  * Extended persistence tiers table with detailed tier information and storage characteristics.
  * Clarified backup strategy using GitHub Actions checkpoints and cron job frequency adjustments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/160)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->