### PR TITLE
docs(fetchers): refresh stale docstrings (merge paths + tec continuous mode)

### DIFF
--- a/scripts/fetch_tec.py
+++ b/scripts/fetch_tec.py
@@ -1,8 +1,10 @@
 """Fetch TEC (IONEX) data from CODE (Bern).
 
-Modes:
-  event  — Fetch around M6.5+ earthquakes ±7 days (existing)
-  random — Fetch random dates ±7 days for control baseline
+Modes (default: continuous):
+  continuous — Fetch all dates 2011-01-01..today (recent-first), capped by
+               TEC_MAX_DATES env (default 100, GHA sets 150).
+  event      — Fetch around M6.5+ earthquakes ±7 days (legacy, opt-in).
+  random     — Fetch random dates ±7 days for control baseline (legacy).
 """
 
 import argparse

--- a/scripts/merge_checkpoints.py
+++ b/scripts/merge_checkpoints.py
@@ -51,12 +51,13 @@ WAL mode:
 
 Usage:
     python3 scripts/merge_checkpoints.py \
-        --base /tmp/light/geohazard.db \
-        --overlay /tmp/modis/geohazard.db:modis_lst \
-        --overlay /tmp/so2/geohazard.db:so2_column \
-        --overlay /tmp/cloud/geohazard.db:cloud_fraction \
-        --overlay /tmp/snet/geohazard.db:snet_waveform \
-        --overlay /tmp/snet/geohazard.db:fnet_waveform \
+        --base /mnt/ssd/runner-temp/light/geohazard.db \
+        --overlay /mnt/ssd/runner-temp/modis/geohazard.db:modis_lst \
+        --overlay /mnt/ssd/runner-temp/so2/geohazard.db:so2_column \
+        --overlay /mnt/ssd/runner-temp/cloud/geohazard.db:cloud_fraction \
+        --overlay /mnt/ssd/runner-temp/snet/geohazard.db:snet_waveform \
+        --overlay /mnt/ssd/runner-temp/snet/geohazard.db:fnet_waveform \
+        --overlay /mnt/ssd/runner-temp/hinet/geohazard.db:hinet_waveform \
         --dst data/geohazard.db \
         --require-base
 


### PR DESCRIPTION
## Summary

2026-05-13 verify で 7 partial-coverage tables を audit した際、 2 つの docstring が **stale** と判明。 機能変更なしの cleanup。

### `scripts/merge_checkpoints.py` Usage block

- **path**: `/tmp/<artifact>/geohazard.db` -> `/mnt/ssd/runner-temp/<artifact>/geohazard.db` (PR #159 で merge job が self-hosted RPi5 runner の SSD scratch へ移行済)
- **missing overlay**: `hinet_waveform` overlay 行を追加 (backfill.yml L2395 で既に invocation されているが docstring 例には欠落していた)

### `scripts/fetch_tec.py` header docstring

- **continuous mode 追記**: `main()` は `--mode continuous` default で 2011-01-01〜today 全期間を recent-first sort で fetch、 `TEC_MAX_DATES` env でキャップ (default 100、 GHA は 150)。 過去 docstring は event/random しか記載しておらず、 現状の運用と整合しない
- event/random は legacy として残置 (opt-in、 後方互換)

## Verification

ast.parse on both modified files: OK (syntax valid)。 機能変更なし。 GHA workflow の merge step は本 PR と関係なく `/mnt/ssd/runner-temp/` を正しく参照しているため、 既存 cron は影響なし。

## Test plan

- [x] Syntax valid on both files
- [ ] CI green (lint/test passes)
- [ ] Merge後 master 同期で run 1 回完走確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced `continuous` mode as the default fetching behavior with recent-first coverage spanning 2011-01-01 to today. Maximum dates retrieved can be customized via the `TEC_MAX_DATES` environment variable (default: 100, GitHub Actions: 150).

* **Documentation**
  * Updated usage examples with revised filesystem paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->