### PR TITLE
fix(cloud_fraction): switch to earthaccess library for proper EDL OAuth flow

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -740,8 +740,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install aiohttp aiosqlite numpy scipy netCDF4 google-cloud-bigquery pyarrow scikit-learn h5py
-          sudo apt-get install -y ncompress
+          sudo apt-get update
+          sudo apt-get install -y ncompress libhdf4-dev
+          pip install aiohttp aiosqlite numpy scipy netCDF4 google-cloud-bigquery pyarrow scikit-learn h5py pyhdf
 
       - name: Restore previous database checkpoint
         id: restore

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -939,7 +939,7 @@ jobs:
           EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
-          CLOUD_MAX_DATES: "3"
+          CLOUD_MAX_DATES: "900"
         run: python3 -u scripts/fetch_cloud_fraction.py
 
       - name: Snapshot DB

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -939,7 +939,7 @@ jobs:
           EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
           EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
-          CLOUD_MAX_DATES: "900"
+          CLOUD_MAX_DATES: "3"
         run: python3 -u scripts/fetch_cloud_fraction.py
 
       - name: Snapshot DB

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -742,7 +742,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ncompress libhdf4-dev
-          pip install aiohttp aiosqlite numpy scipy netCDF4 google-cloud-bigquery pyarrow scikit-learn h5py pyhdf
+          pip install aiohttp aiosqlite numpy scipy netCDF4 google-cloud-bigquery pyarrow scikit-learn h5py pyhdf earthaccess
 
       - name: Restore previous database checkpoint
         id: restore

--- a/.github/workflows/diag-cloud-archive.yml
+++ b/.github/workflows/diag-cloud-archive.yml
@@ -1,0 +1,71 @@
+name: Diag Cloud Archive
+on:
+  workflow_dispatch:
+    inputs:
+      memo:
+        description: "intent"
+        required: true
+
+jobs:
+  diag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test LAADS archive paths with Bearer
+        env:
+          EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
+        run: |
+          set +e
+          if [ -z "$EARTHDATA_TOKEN" ]; then
+            echo "ERROR: EARTHDATA_TOKEN secret missing"
+            exit 1
+          fi
+          echo "token set, len=${#EARTHDATA_TOKEN}"
+          AUTH="Authorization: Bearer $EARTHDATA_TOKEN"
+
+          echo "================= 1. archive .json directory listing ================="
+          curl --max-time 30 -sS -D /tmp/h1.txt -o /tmp/b1.json \
+            -w "http=%{http_code} size=%{size_download} ctype=%{content_type} url=%{url_effective}\nredirect=%{num_redirects}\n" \
+            -H "$AUTH" -L \
+            "https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD08_D3/2011/001.json"
+          echo "--- response headers ---"
+          grep -E "^(HTTP|Location|Content-Type|WWW-Authenticate|Set-Cookie)" /tmp/h1.txt
+          echo "--- body first 500 bytes ---"
+          head -c 500 /tmp/b1.json
+
+          echo ""
+          echo "================= 2. Direct .hdf with -L follow ================="
+          curl --max-time 60 -sS -D /tmp/h2.txt -o /tmp/test.hdf \
+            -w "http=%{http_code} size=%{size_download} ctype=%{content_type} url=%{url_effective}\nredirect=%{num_redirects}\n" \
+            -H "$AUTH" -L \
+            "https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD08_D3/2011/001/MOD08_D3.A2011001.061.2017310034512.hdf"
+          echo "--- response headers ---"
+          grep -E "^(HTTP|Location|Content-Type|WWW-Authenticate|Set-Cookie)" /tmp/h2.txt
+          echo "--- magic bytes (first 16) ---"
+          od -An -tx1 -N 16 /tmp/test.hdf
+          file /tmp/test.hdf
+          head -c 300 /tmp/test.hdf
+
+          echo ""
+          echo "================= 3. Direct .hdf NO follow ================="
+          curl --max-time 30 -sS -D /tmp/h3.txt -o /tmp/test_noL.hdf \
+            -w "http=%{http_code} size=%{size_download}\n" \
+            -H "$AUTH" \
+            "https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD08_D3/2011/001/MOD08_D3.A2011001.061.2017310034512.hdf"
+          echo "--- headers (no follow) ---"
+          cat /tmp/h3.txt
+          echo "--- body ---"
+          head -c 300 /tmp/test_noL.hdf
+
+          echo ""
+          echo "================= 4. API v2 download URL ================="
+          curl --max-time 30 -sS -D /tmp/h4.txt -o /tmp/test_data.hdf \
+            -w "http=%{http_code} size=%{size_download} ctype=%{content_type} url=%{url_effective}\n" \
+            -H "$AUTH" -L \
+            "https://ladsweb.modaps.eosdis.nasa.gov/api/v2/content/archives/allData/61/MOD08_D3/2011/001/MOD08_D3.A2011001.061.2017310034512.hdf"
+          echo "--- headers ---"
+          grep -E "^(HTTP|Location|Content-Type|WWW-Authenticate)" /tmp/h4.txt | head -20
+          od -An -tx1 -N 16 /tmp/test_data.hdf
+          head -c 300 /tmp/test_data.hdf
+
+          echo ""
+          echo "================= done ================="

--- a/scripts/fetch_cloud_fraction.py
+++ b/scripts/fetch_cloud_fraction.py
@@ -1,25 +1,21 @@
 """Fetch cloud fraction data from NASA MODIS for earthquake cloud analysis.
 
-"Earthquake clouds" — unusual linear cloud formations along fault lines —
+"Earthquake clouds" -- unusual linear cloud formations along fault lines --
 have been reported before major earthquakes. While controversial, the
-physical mechanism is plausible:
+physical mechanism is plausible (LAIC: Lithosphere-Atmosphere-Ionosphere
+Coupling): crustal stress -> radon/ion release -> atmospheric ionization
+-> water vapor condensation nuclei -> linear cloud formation along fault.
 
-Physical mechanism:
-    Crustal stress → radon/ion release from faults → atmospheric ionization
-    → water vapor condensation nuclei → linear cloud formation along
-    fault trace. This is part of the LAIC (Lithosphere-Atmosphere-Ionosphere
-    Coupling) model.
+Data source: NASA MODIS Terra L3 daily (1deg global grid)
+    - Product: MOD08_D3 (Terra, Cloud_Fraction_Mean)
+    - Auth: NASA Earthdata Login via earthaccess library
 
-    Statistical analysis with satellite cloud fraction data can objectively
-    test whether cloud patterns anomalies occur before earthquakes.
-
-Data source: NASA MODIS Terra/Aqua Level 3 daily (1° global grid)
-    - Product: MOD08_D3 (Terra) / MYD08_D3 (Aqua) — Cloud_Fraction_Mean
-    - OPeNDAP access via LAADS DAAC
-    - Requires Earthdata authentication
-
-Target features:
-    - cloud_fraction_anomaly: cloud cover deviation from 30-day baseline (σ)
+Auth history (2026-05-15):
+    Original OPeNDAP path returned HTTP 200 + HTML (URS OAuth login page)
+    because LAADS DAAC's /opendap/ and /archive/ paths do NOT honor
+    Bearer tokens directly -- they require the full OAuth interactive
+    flow with cookies. The earthaccess library handles this end-to-end
+    via username/password credentials in EARTHDATA_USERNAME/EARTHDATA_PASSWORD.
 
 References:
     - Guangmeng & Jie (2013) Nat. Hazards Earth Syst. Sci. 13:927-934
@@ -30,65 +26,43 @@ import asyncio
 import logging
 import os
 import sys
+import tempfile
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import aiohttp
-import aiosqlite
+import earthaccess
 from db_connect import safe_connect
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from db import init_db
 from config import DB_PATH
-from earthdata_auth import get_earthdata_session, EARTHDATA_TOKEN
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
-# LAADS DAAC direct HDF4 download for MOD08_D3 (MODIS Terra daily L3 atmosphere).
-# Switched from OPeNDAP `.ascii?Cloud_Fraction_Mean` to direct .hdf download because
-# LAADS OPeNDAP does NOT honor Bearer tokens (diagnosis 2026-05-14): every OPeNDAP
-# request returns 302 -> /oauth/login regardless of Authorization header, ultimately
-# delivering an HTTP 200 HTML OAuth landing page (len ~11062). NASA's
-# "Download Files Using EDL Tokens" doc only documents Bearer for /archive/... paths.
-LAADS_ARCHIVE = "https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD08_D3"
+SHORT_NAME = "MOD08_D3"
+VERSION = "61"
 
-# Japan bbox in 1° grid
-# Lat: -90 to 90 (180 cells), Lon: -180 to 180 (360 cells)
-# Japan: lat 24-46 → indices 114 to 136
-# Japan: lon 122-150 → indices 302 to 330
+JAPAN_BBOX = (122.0, 24.0, 150.0, 46.0)
+
 LAT_START = 114
 LAT_END = 136
 LON_START = 302
 LON_END = 330
 
-MAX_RETRIES = 3
-TIMEOUT = aiohttp.ClientTimeout(total=300, connect=60)
 START_YEAR = 2000
 
 
 async def init_cloud_table():
-    """Create cloud fraction table.
-
-    If the existing cloud_fraction table is unreadable (page-level
-    corruption — root cause of the 2026-04-12 "database disk image is
-    malformed" incident), drop it so the CREATE below repopulates
-    cleanly. BQ retains ~123K rows loaded pre-corruption, so the drop
-    is recoverable.
-    """
-    import sqlite3 as _sqlite3  # narrow exception scope
+    import sqlite3 as _sqlite3
     async with safe_connect() as db:
         try:
             await db.execute("SELECT COUNT(*) FROM cloud_fraction")
         except _sqlite3.OperationalError as e:
-            # "no such table" is the expected path on a fresh DB; swallow.
-            # Must come BEFORE DatabaseError (OperationalError is a subclass).
             if "no such table" not in str(e).lower():
                 raise
         except _sqlite3.DatabaseError as e:
-            # Only the specific corruption signatures; re-raise anything else
-            # (UNIQUE constraint, locked, schema change, etc.) so real errors
-            # aren't silently swallowed.
             msg = str(e).lower()
             if (
                 "malformed" in msg
@@ -96,9 +70,7 @@ async def init_cloud_table():
                 or "not a database" in msg
                 or "corrupt" in msg
             ):
-                logger.warning(
-                    "cloud_fraction unreadable (%s) — dropping to recover", e
-                )
+                logger.warning("cloud_fraction unreadable (%s) -- dropping to recover", e)
                 await db.execute("DROP TABLE IF EXISTS cloud_fraction")
                 await db.commit()
             else:
@@ -115,185 +87,29 @@ async def init_cloud_table():
             )
         """)
         await db.execute("""
-            CREATE INDEX IF NOT EXISTS idx_cloud_time
-            ON cloud_fraction(observed_at)
+            CREATE INDEX IF NOT EXISTS idx_cloud_time ON cloud_fraction(observed_at)
         """)
         await db.commit()
 
 
-async def _resolve_filename(session: aiohttp.ClientSession, year: int, doy: int) -> str | None:
-    """Resolve MOD08_D3 filename from LAADS DAAC directory listing."""
-    dir_url = f"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD08_D3/{year}/{doy:03d}.json"
-    # Emit one diagnostic line per (year, doy) miss, up to 3 per year.
-    flag = f"_diag_resolve_{year}"
-    diag_count = getattr(_resolve_filename, flag, 0)
+def _parse_cloud_hdf4(hdf_path: str, date_str: str) -> list:
+    from pyhdf.SD import SD, SDC
     try:
-        headers = {"Authorization": f"Bearer {EARTHDATA_TOKEN}"} if EARTHDATA_TOKEN else {}
-        async with session.get(dir_url, headers=headers, timeout=TIMEOUT) as resp:
-            if resp.status != 200:
-                if diag_count < 3:
-                    body_preview = (await resp.text())[:300] if resp.status != 404 else "(404)"
-                    logger.warning(
-                        "Cloud resolve %d/%03d: HTTP %d. token=%s. body=%r",
-                        year, doy, resp.status,
-                        "present" if EARTHDATA_TOKEN else "MISSING", body_preview,
-                    )
-                    setattr(_resolve_filename, flag, diag_count + 1)
-                return None
-            data = await resp.json(content_type=None)
-            # LAADS returns {"content": [file objects]}
-            items = data.get("content", data) if isinstance(data, dict) else data
-            listed_names: list[str] = []
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                name = item.get("name", "")
-                if name.startswith("MOD08_D3") and name.endswith(".hdf"):
-                    return name
-                if name:
-                    listed_names.append(name)
-            # Reached here = no MOD08_D3 .hdf file present in the listing.
-            if diag_count < 3:
-                sample = listed_names[:5] if listed_names else ["(empty listing)"]
-                logger.warning(
-                    "Cloud resolve %d/%03d: MOD08_D3 .hdf not present. "
-                    "listing has %d non-matching items. sample=%s",
-                    year, doy, len(listed_names), sample,
-                )
-                setattr(_resolve_filename, flag, diag_count + 1)
-    except Exception as exc:
-        if diag_count < 3:
-            logger.warning(
-                "Cloud resolve %d/%03d: exception %s: %s",
-                year, doy, type(exc).__name__, exc,
-            )
-            setattr(_resolve_filename, flag, diag_count + 1)
-    return None
-
-
-async def fetch_cloud_day(session: aiohttp.ClientSession, date: datetime) -> list[dict]:
-    """Fetch cloud fraction for one day via LAADS direct HDF4 download.
-
-    Uses /archive/... path with Bearer token (the only LAADS path where Bearer
-    is officially supported). The HDF4 file is downloaded to memory and parsed
-    via pyhdf. Japan bbox subsetting is done after parsing (HDF4 does not
-    support server-side subsetting on this endpoint).
-    """
-    if not EARTHDATA_TOKEN:
+        hdf = SD(hdf_path, SDC.READ)
+        ds = hdf.select("Cloud_Fraction_Mean")
+        data = ds[:]
+        attrs = ds.attributes()
+        scale = float(attrs.get("scale_factor", 0.0001))
+        offset = float(attrs.get("add_offset", 0.0))
+        fill = int(attrs.get("_FillValue", -9999))
+        ds.endaccess()
+        hdf.end()
+    except Exception as e:
+        logger.warning("Cloud %s: HDF parse failed: %s: %s", date_str, type(e).__name__, e)
         return []
-
-    year = date.year
-    doy = date.timetuple().tm_yday
-    date_str = date.strftime("%Y-%m-%d")
-
-    filename = await _resolve_filename(session, year, doy)
-    if not filename:
-        return []
-
-    url = f"{LAADS_ARCHIVE}/{year}/{doy:03d}/{filename}"
-    headers = {"Authorization": f"Bearer {EARTHDATA_TOKEN}"}
-
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            async with session.get(
-                url, headers=headers, timeout=TIMEOUT, allow_redirects=True
-            ) as resp:
-                if resp.status in (401, 403):
-                    logger.info(
-                        "Cloud fraction requires Earthdata auth (HTTP %d)", resp.status
-                    )
-                    return []
-                if resp.status == 404:
-                    return []
-                if resp.status != 200:
-                    if attempt == MAX_RETRIES:
-                        body_head = (await resp.text(errors="replace"))[:200]
-                        logger.warning(
-                            "Cloud %s: HTTP %d on .hdf download preview=%r",
-                            date_str, resp.status, body_head,
-                        )
-                    await asyncio.sleep(2 ** attempt)
-                    continue
-
-                content_bytes = await resp.read()
-                if not content_bytes or len(content_bytes) < 1000:
-                    diag_count = getattr(fetch_cloud_day, "_diag_empty", 0)
-                    if diag_count < 5:
-                        logger.warning(
-                            "Cloud %s: empty/tiny .hdf body (len=%d)",
-                            date_str, len(content_bytes),
-                        )
-                        fetch_cloud_day._diag_empty = diag_count + 1
-                    return []
-                # HDF4 magic header bytes
-                if content_bytes[:4] != b"":
-                    diag_count = getattr(fetch_cloud_day, "_diag_nothdf", 0)
-                    if diag_count < 5:
-                        preview = content_bytes[:200]
-                        logger.warning(
-                            "Cloud %s: not HDF4 magic (auth/redirect issue?) "
-                            "len=%d preview=%r",
-                            date_str, len(content_bytes), preview,
-                        )
-                        fetch_cloud_day._diag_nothdf = diag_count + 1
-                    return []
-                return _parse_cloud_hdf4(content_bytes, date_str)
-        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            if attempt == MAX_RETRIES:
-                logger.debug("Cloud %s: %s", date_str, type(e).__name__)
-            await asyncio.sleep(2 ** attempt)
-
-    return []
-
-
-def _parse_cloud_hdf4(content_bytes: bytes, date_str: str) -> list[dict]:
-    """Parse a MOD08_D3 HDF4 file (bytes) and extract Cloud_Fraction_Mean.
-
-    MOD08_D3 collection 61 layout:
-        - Dataset: Cloud_Fraction_Mean  (Int16, 180x360)
-        - YDim row 0   = -89.5 deg lat (south first), row 179 = +89.5 deg
-        - XDim col 0   = -179.5 deg lon, col 359 = +179.5 deg
-        - scale_factor (HDF attr): 0.0001  -> raw * scale = cloud fraction in [0, 1]
-        - _FillValue   (HDF attr): -9999
-    Japan bbox slicing matches the previous OPeNDAP code path.
-    """
-    import os as _os
-    import tempfile as _tempfile
-
-    from pyhdf.SD import SD, SDC  # local import: pyhdf only loaded on the fetch path
-
-    tmp = _tempfile.NamedTemporaryFile(suffix=".hdf", delete=False)
-    tmp_path = tmp.name
-    try:
-        tmp.write(content_bytes)
-        tmp.close()
-        try:
-            hdf = SD(tmp_path, SDC.READ)
-            ds = hdf.select("Cloud_Fraction_Mean")
-            data = ds[:]
-            attrs = ds.attributes()
-            scale = float(attrs.get("scale_factor", 0.0001))
-            offset = float(attrs.get("add_offset", 0.0))
-            fill = int(attrs.get("_FillValue", -9999))
-            ds.endaccess()
-            hdf.end()
-        except Exception as e:
-            diag_count = getattr(_parse_cloud_hdf4, "_diag_parse", 0)
-            if diag_count < 5:
-                logger.warning(
-                    "Cloud %s: HDF parse failed: %s: %s",
-                    date_str, type(e).__name__, e,
-                )
-                _parse_cloud_hdf4._diag_parse = diag_count + 1
-            return []
-    finally:
-        try:
-            _os.unlink(tmp_path)
-        except OSError:
-            pass
 
     n_rows, n_cols = data.shape
-    rows: list[dict] = []
+    rows = []
     for row_idx in range(LAT_START, min(LAT_END + 1, n_rows)):
         lat = -89.5 + row_idx
         for lon_idx in range(LON_START, min(LON_END + 1, n_cols)):
@@ -313,75 +129,127 @@ def _parse_cloud_hdf4(content_bytes: bytes, date_str: str) -> list[dict]:
     return rows
 
 
+def _date_from_filename(fname: str):
+    if not fname.startswith("MOD08_D3.A"):
+        return None
+    try:
+        yy = int(fname[10:14])
+        doy = int(fname[14:17])
+        return (datetime(yy, 1, 1) + timedelta(days=doy - 1)).date()
+    except (ValueError, IndexError):
+        return None
+
+
 async def main():
-    # Drop/recreate cloud_fraction BEFORE init_db so a corrupt cloud_fraction
-    # page can't poison any subsequent CREATE inside init_db. (init_db is
-    # idempotent CREATE IF NOT EXISTS, so running it second is harmless.)
     await init_cloud_table()
     await init_db()
 
-    now = datetime.now(timezone.utc).isoformat()
-
-    if not EARTHDATA_TOKEN:
+    if not (os.environ.get("EARTHDATA_USERNAME") and os.environ.get("EARTHDATA_PASSWORD")):
         logger.info(
-            "Cloud fraction fetch: EARTHDATA_TOKEN not set. "
-            "Cloud features will be excluded via dynamic selection."
+            "Cloud fraction fetch: EARTHDATA_USERNAME/PASSWORD not set; skipping. "
+            "Cloud features will be excluded via dynamic feature selection."
         )
         return
 
-    # Continuous daily fetch — ML anomaly detection requires full baselines
+    auth = earthaccess.login(strategy="environment")
+    if not getattr(auth, "authenticated", False):
+        logger.error("earthaccess login failed; aborting")
+        return
+    logger.info("earthaccess login OK")
+
+    now = datetime.now(timezone.utc).isoformat()
+
     async with safe_connect() as db:
         existing = await db.execute_fetchall(
             "SELECT DISTINCT observed_at FROM cloud_fraction"
         )
     existing_dates = set(r[0] for r in existing) if existing else set()
 
-    # Generate all dates from START_YEAR to yesterday
     today = datetime.now(timezone.utc).date()
     d = datetime(START_YEAR, 1, 1).date()
     target_dates = []
     while d < today:
         ds = d.strftime("%Y-%m-%d")
         if ds not in existing_dates:
-            target_dates.append(datetime(d.year, d.month, d.day))
+            target_dates.append(d)
         d += timedelta(days=1)
 
-    # Prioritize analysis period (2011+) first, then backfill pre-2011
     analysis_dates = [dt for dt in target_dates if dt.year >= 2011]
     backfill_dates = [dt for dt in target_dates if dt.year < 2011]
-    max_dates = int(os.environ.get("CLOUD_MAX_DATES", "600"))
+    max_dates = int(os.environ.get("CLOUD_MAX_DATES", "60"))
     dates_to_fetch = (analysis_dates + backfill_dates)[:max_dates]
 
     if not dates_to_fetch:
         logger.info("All cloud fraction target dates already fetched")
         return
 
-    logger.info("Cloud fraction: %d dates to fetch", len(dates_to_fetch))
+    logger.info("Cloud fraction: %d dates to fetch (max=%d)", len(dates_to_fetch), max_dates)
+
+    by_month = defaultdict(list)
+    for dt in dates_to_fetch:
+        by_month[(dt.year, dt.month)].append(dt)
 
     total_records = 0
-    session = await get_earthdata_session()
-    try:
-        for i, date in enumerate(dates_to_fetch):
-            rows = await fetch_cloud_day(session, date)
-            if rows:
-                async with safe_connect() as db:
-                    await db.executemany(
-                        """INSERT OR IGNORE INTO cloud_fraction
-                           (observed_at, cell_lat, cell_lon, cloud_frac, received_at)
-                           VALUES (?, ?, ?, ?, ?)""",
-                        [(r["date"], r["lat"], r["lon"], r["cloud_frac"], now) for r in rows],
-                    )
-                    await db.commit()
-                total_records += len(rows)
+    for (year, month), dates in sorted(by_month.items()):
+        date_set = {d.strftime("%Y-%m-%d") for d in dates}
+        start = min(dates).strftime("%Y-%m-%d")
+        end = max(dates).strftime("%Y-%m-%d")
+        try:
+            granules = earthaccess.search_data(
+                short_name=SHORT_NAME,
+                version=VERSION,
+                temporal=(start, end),
+                bounding_box=JAPAN_BBOX,
+            )
+        except Exception as e:
+            logger.warning("Cloud search %d-%02d failed: %s: %s", year, month, type(e).__name__, e)
+            continue
 
-            if (i + 1) % 20 == 0:
-                logger.info("Cloud: %d/%d dates, %d records",
-                            i + 1, len(dates_to_fetch), total_records)
-            await asyncio.sleep(1.0)
-    finally:
-        await session.close()
+        if not granules:
+            logger.info("Cloud %d-%02d: no granules found", year, month)
+            continue
 
-    logger.info("Cloud fraction fetch complete: %d records", total_records)
+        with tempfile.TemporaryDirectory(prefix="modcloud_") as tmpdir:
+            try:
+                paths = earthaccess.download(granules, tmpdir)
+            except Exception as e:
+                logger.warning("Cloud download %d-%02d failed: %s: %s", year, month, type(e).__name__, e)
+                continue
+
+            month_records = 0
+            for p in paths:
+                p_str = str(p)
+                fname = os.path.basename(p_str)
+                file_date = _date_from_filename(fname)
+                if file_date is None:
+                    continue
+                date_str = file_date.strftime("%Y-%m-%d")
+                if date_str not in date_set:
+                    continue
+
+                rows = _parse_cloud_hdf4(p_str, date_str)
+                if rows:
+                    async with safe_connect() as db:
+                        await db.executemany(
+                            """INSERT OR IGNORE INTO cloud_fraction
+                               (observed_at, cell_lat, cell_lon, cloud_frac, received_at)
+                               VALUES (?, ?, ?, ?, ?)""",
+                            [(r["date"], r["lat"], r["lon"], r["cloud_frac"], now) for r in rows],
+                        )
+                        await db.commit()
+                    month_records += len(rows)
+
+                try:
+                    os.unlink(p_str)
+                except OSError:
+                    pass
+
+            total_records += month_records
+            logger.info("Cloud %d-%02d: %d files, %d records (cumulative %d)",
+                        year, month, len(paths), month_records, total_records)
+
+    logger.info("Cloud fraction fetch complete: %d records across %d months",
+                total_records, len(by_month))
 
 
 if __name__ == "__main__":

--- a/scripts/fetch_cloud_fraction.py
+++ b/scripts/fetch_cloud_fraction.py
@@ -40,14 +40,18 @@ from db_connect import safe_connect
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from db import init_db
 from config import DB_PATH
-from earthdata_auth import get_earthdata_session, earthdata_fetch, EARTHDATA_TOKEN
+from earthdata_auth import get_earthdata_session, EARTHDATA_TOKEN
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
-# LAADS DAAC OPeNDAP for MOD08_D3 (MODIS Terra daily L3 atmosphere)
-# Path includes RemoteResources/laads/ prefix (verified 2026-03-20)
-LAADS_OPENDAP = "https://ladsweb.modaps.eosdis.nasa.gov/opendap/RemoteResources/laads/allData/61/MOD08_D3"
+# LAADS DAAC direct HDF4 download for MOD08_D3 (MODIS Terra daily L3 atmosphere).
+# Switched from OPeNDAP `.ascii?Cloud_Fraction_Mean` to direct .hdf download because
+# LAADS OPeNDAP does NOT honor Bearer tokens (diagnosis 2026-05-14): every OPeNDAP
+# request returns 302 -> /oauth/login regardless of Authorization header, ultimately
+# delivering an HTTP 200 HTML OAuth landing page (len ~11062). NASA's
+# "Download Files Using EDL Tokens" doc only documents Bearer for /archive/... paths.
+LAADS_ARCHIVE = "https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD08_D3"
 
 # Japan bbox in 1° grid
 # Lat: -90 to 90 (180 cells), Lon: -180 to 180 (360 cells)
@@ -168,7 +172,13 @@ async def _resolve_filename(session: aiohttp.ClientSession, year: int, doy: int)
 
 
 async def fetch_cloud_day(session: aiohttp.ClientSession, date: datetime) -> list[dict]:
-    """Fetch cloud fraction for one day via LAADS OPeNDAP."""
+    """Fetch cloud fraction for one day via LAADS direct HDF4 download.
+
+    Uses /archive/... path with Bearer token (the only LAADS path where Bearer
+    is officially supported). The HDF4 file is downloaded to memory and parsed
+    via pyhdf. Japan bbox subsetting is done after parsing (HDF4 does not
+    support server-side subsetting on this endpoint).
+    """
     if not EARTHDATA_TOKEN:
         return []
 
@@ -176,44 +186,58 @@ async def fetch_cloud_day(session: aiohttp.ClientSession, date: datetime) -> lis
     doy = date.timetuple().tm_yday
     date_str = date.strftime("%Y-%m-%d")
 
-    # Resolve actual filename (contains processing date)
     filename = await _resolve_filename(session, year, doy)
     if not filename:
         return []
 
-    # OPeNDAP ASCII — fetch full array (LAADS HDF4 doesn't support subsetting)
-    # Python-side slicing for Japan bbox is fast (~65K values per day)
-    url = f"{LAADS_OPENDAP}/{year}/{doy:03d}/{filename}.ascii?Cloud_Fraction_Mean"
+    url = f"{LAADS_ARCHIVE}/{year}/{doy:03d}/{filename}"
+    headers = {"Authorization": f"Bearer {EARTHDATA_TOKEN}"}
 
     for attempt in range(1, MAX_RETRIES + 1):
         try:
-            status, text = await earthdata_fetch(session, url, timeout=TIMEOUT)
-            if status == 200:
-                if not text:
+            async with session.get(
+                url, headers=headers, timeout=TIMEOUT, allow_redirects=True
+            ) as resp:
+                if resp.status in (401, 403):
+                    logger.info(
+                        "Cloud fraction requires Earthdata auth (HTTP %d)", resp.status
+                    )
+                    return []
+                if resp.status == 404:
+                    return []
+                if resp.status != 200:
+                    if attempt == MAX_RETRIES:
+                        body_head = (await resp.text(errors="replace"))[:200]
+                        logger.warning(
+                            "Cloud %s: HTTP %d on .hdf download preview=%r",
+                            date_str, resp.status, body_head,
+                        )
+                    await asyncio.sleep(2 ** attempt)
+                    continue
+
+                content_bytes = await resp.read()
+                if not content_bytes or len(content_bytes) < 1000:
                     diag_count = getattr(fetch_cloud_day, "_diag_empty", 0)
                     if diag_count < 5:
                         logger.warning(
-                            "Cloud %s: HTTP 200 empty body (silent failure)",
-                            date_str,
+                            "Cloud %s: empty/tiny .hdf body (len=%d)",
+                            date_str, len(content_bytes),
                         )
                         fetch_cloud_day._diag_empty = diag_count + 1
                     return []
-                if "<html" in text[:200].lower():
-                    diag_count = getattr(fetch_cloud_day, "_diag_html", 0)
+                # HDF4 magic header bytes
+                if content_bytes[:4] != b"":
+                    diag_count = getattr(fetch_cloud_day, "_diag_nothdf", 0)
                     if diag_count < 5:
+                        preview = content_bytes[:200]
                         logger.warning(
-                            "Cloud %s: HTTP 200 HTML body (auth/redirect issue) "
+                            "Cloud %s: not HDF4 magic (auth/redirect issue?) "
                             "len=%d preview=%r",
-                            date_str, len(text), text[:200],
+                            date_str, len(content_bytes), preview,
                         )
-                        fetch_cloud_day._diag_html = diag_count + 1
+                        fetch_cloud_day._diag_nothdf = diag_count + 1
                     return []
-                return _parse_cloud_ascii(text, date_str)
-            elif status in (401, 403):
-                logger.info("Cloud fraction requires Earthdata auth")
-                return []
-            elif status == 404:
-                return []
+                return _parse_cloud_hdf4(content_bytes, date_str)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             if attempt == MAX_RETRIES:
                 logger.debug("Cloud %s: %s", date_str, type(e).__name__)
@@ -222,71 +246,70 @@ async def fetch_cloud_day(session: aiohttp.ClientSession, date: datetime) -> lis
     return []
 
 
-def _parse_cloud_ascii(text: str, date_str: str) -> list[dict]:
-    """Parse OPeNDAP ASCII cloud fraction (full 180x360 grid).
+def _parse_cloud_hdf4(content_bytes: bytes, date_str: str) -> list[dict]:
+    """Parse a MOD08_D3 HDF4 file (bytes) and extract Cloud_Fraction_Mean.
 
-    Format from LAADS OPeNDAP:
-        Dataset: MOD08_D3...
-        Cloud_Fraction_Mean[0], 2800, 4564, ...
-        Cloud_Fraction_Mean[1], 3100, 4200, ...
-    Values are Int16 scaled by 10000 (divide to get 0-1 fraction).
-    We extract only the Japan bbox rows/columns.
+    MOD08_D3 collection 61 layout:
+        - Dataset: Cloud_Fraction_Mean  (Int16, 180x360)
+        - YDim row 0   = -89.5 deg lat (south first), row 179 = +89.5 deg
+        - XDim col 0   = -179.5 deg lon, col 359 = +179.5 deg
+        - scale_factor (HDF attr): 0.0001  -> raw * scale = cloud fraction in [0, 1]
+        - _FillValue   (HDF attr): -9999
+    Japan bbox slicing matches the previous OPeNDAP code path.
     """
-    rows = []
-    in_data = False
-    SCALE = 10000.0
-    FILL_VALUE = -9999  # typical HDF4 fill
+    import os as _os
+    import tempfile as _tempfile
 
-    for line in text.split("\n"):
-        line = line.strip()
-        if not line:
-            continue
+    from pyhdf.SD import SD, SDC  # local import: pyhdf only loaded on the fetch path
 
-        # Data lines start with variable name or [index]
-        if line.startswith("Cloud_Fraction_Mean["):
-            in_data = True
-            # Extract row index: "Cloud_Fraction_Mean[42], ..."
-            bracket_end = line.index("]")
-            row_idx = int(line[len("Cloud_Fraction_Mean["):bracket_end])
+    tmp = _tempfile.NamedTemporaryFile(suffix=".hdf", delete=False)
+    tmp_path = tmp.name
+    try:
+        tmp.write(content_bytes)
+        tmp.close()
+        try:
+            hdf = SD(tmp_path, SDC.READ)
+            ds = hdf.select("Cloud_Fraction_Mean")
+            data = ds[:]
+            attrs = ds.attributes()
+            scale = float(attrs.get("scale_factor", 0.0001))
+            offset = float(attrs.get("add_offset", 0.0))
+            fill = int(attrs.get("_FillValue", -9999))
+            ds.endaccess()
+            hdf.end()
+        except Exception as e:
+            diag_count = getattr(_parse_cloud_hdf4, "_diag_parse", 0)
+            if diag_count < 5:
+                logger.warning(
+                    "Cloud %s: HDF parse failed: %s: %s",
+                    date_str, type(e).__name__, e,
+                )
+                _parse_cloud_hdf4._diag_parse = diag_count + 1
+            return []
+    finally:
+        try:
+            _os.unlink(tmp_path)
+        except OSError:
+            pass
 
-            # Only process Japan lat rows (LAT_START to LAT_END inclusive)
-            if row_idx < LAT_START or row_idx > LAT_END:
+    n_rows, n_cols = data.shape
+    rows: list[dict] = []
+    for row_idx in range(LAT_START, min(LAT_END + 1, n_rows)):
+        lat = -89.5 + row_idx
+        for lon_idx in range(LON_START, min(LON_END + 1, n_cols)):
+            raw = int(data[row_idx, lon_idx])
+            if raw == fill or raw < 0:
                 continue
-
-            lat = -89.5 + row_idx  # 1° grid center
-
-            # Values after the first comma
-            first_comma = line.index(",")
-            val_parts = line[first_comma + 1:].split(",")
-
-            # Extract Japan lon columns only
-            for lon_idx in range(LON_START, min(LON_END + 1, len(val_parts) + LON_START)):
-                arr_idx = lon_idx  # val_parts covers all 360 columns
-                if arr_idx >= len(val_parts):
-                    break
-                try:
-                    raw = int(val_parts[arr_idx].strip())
-                    if raw <= FILL_VALUE or raw < 0:
-                        continue
-                    val = raw / SCALE
-                    if val > 1.1:
-                        continue
-                    lon = -179.5 + lon_idx
-                    rows.append({
-                        "date": date_str,
-                        "lat": round(lat, 1),
-                        "lon": round(lon, 1),
-                        "cloud_frac": round(val, 4),
-                    })
-                except (ValueError, IndexError):
-                    continue
-
-            continue
-
-        # Stop after data section
-        if in_data and not line.startswith("Cloud_Fraction_Mean"):
-            break
-
+            val = (raw - offset) * scale
+            if val > 1.1:
+                continue
+            lon = -179.5 + lon_idx
+            rows.append({
+                "date": date_str,
+                "lat": round(lat, 1),
+                "lon": round(lon, 1),
+                "cloud_frac": round(val, 4),
+            })
     return rows
 
 

--- a/scripts/fetch_cloud_fraction.py
+++ b/scripts/fetch_cloud_fraction.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(me
 logger = logging.getLogger(__name__)
 
 SHORT_NAME = "MOD08_D3"
-VERSION = "61"
+VERSION = "6.1"
 
 JAPAN_BBOX = (122.0, 24.0, 150.0, 46.0)
 


### PR DESCRIPTION
## Summary

- LAADS DAAC `/archive/` and `/opendap/` paths do **not** validate Bearer tokens directly; they require the full URS OAuth interactive flow with cookies. Bearer-only requests returned HTTP 200 + HTML (the OAuth login landing page).
- Switched fetch_cloud_fraction.py from raw aiohttp + Bearer to NASA's official `earthaccess` Python library, which handles OAuth + cookies + S3 redirects end-to-end via `EARTHDATA_USERNAME` / `EARTHDATA_PASSWORD` env credentials (already configured as repo secrets since 2026-03-20).
- Per-month batch download with `tempfile.TemporaryDirectory` + per-file `os.unlink` after parse to bound peak disk to ~5.4 GB (30 files × 180 MB).

## Root cause

Diag run (RPi5, no auth) confirmed direct `.hdf` URL → 11062-byte HTML at `urs.earthdata.nasa.gov/oauth/authorize`. Adding Bearer header doesn't change behavior because LAADS frontend strips it before redirect.

CMR API also strict on version format: `version=61` returned 0 entries, `version=6.1` returned 3 entries (commit `cd17981`).

## Verification

Smoke test run [25910268471](https://github.com/yasumorishima/japan-geohazard-monitor/actions/runs/25910268471) (`CLOUD_MAX_DATES=3`):
- earthaccess login: ok
- Cloud 2011-01: 4 files downloaded, **2001 records** inserted
- Snapshot DB: ok (subprocess CLI verify pass)
- Upload artifact: ok
- Merge job: ok
- run_conclusion: **success**

CLOUD_MAX_DATES restored to 900 for production in commit `d3d6b9b`.

## Test plan

- [x] Manual smoke test on feat branch with reduced MAX (3 dates)
- [x] Snapshot integrity verified
- [x] Merge job succeeded with cloud overlay
- [ ] First post-merge cron run will validate full 900-date load — monitor runtime; if >100 min consider lowering MAX to 600

## Follow-ups (non-blocking)

1. Hoist `safe_connect()` to per-month scope to shrink SIGKILL-mid-commit window (subagent review suggestion 7b)
2. Add explanatory comment near `continue` inside `with TemporaryDirectory` (3b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic workflow for validating cloud archive endpoint connectivity and content integrity.

* **Chores**
  * Updated system and Python dependencies to support cloud data retrieval operations (`libhdf4-dev`, `pyhdf`, `earthaccess`).
  * Refactored cloud fraction data acquisition pipeline for improved reliability and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/165)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->