### PR TITLE
Cloud-native backfill: retire RPi5 SSD, Hugging Face as canonical store

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -18,17 +18,23 @@ name: Backfill Data
 #                                 + S-net waveform
 #                                 + S-net pressure   -> snet.db artifact
 #   light        (timeout 200m): remaining ~26 fetchers -> light.db artifact
-#   merge        (timeout 60m):  needs all 5 above, runs
+#   merge        (ubuntu-latest): needs all above, runs
 #                                 scripts/merge_checkpoints.py with light
-#                                 as base and 4 overlays.
+#                                 as base and the per-table overlays.
 #                                 Then Snapshot / Coverage / Upload
-#                                 checkpoint (target ガード) / Upload BQ
-#                                 (target ガード) / Discord / Issue.
+#                                 checkpoint artifact (target ガード) /
+#                                 Upload canonical DB to Hugging Face
+#                                 (UTC 00:00 cron のみ) / Discord / Issue.
+#
+# Storage: the GitHub artifact chain (backfill-checkpoint-<run_id>) is the
+# per-run working state restored by each fetch job. The Hugging Face dataset
+# yasumorishima/japan-geohazard is the canonical durable copy (the retired
+# RPi5 SSD primary tier was replaced by HF on 2026-05-28).
 #
 # If a fetch job is target-skipped (workflow_dispatch with a specific
 # target) or cancelled / fails, its overlay artifact is absent and
 # merge_checkpoints.py leaves those tables as the base's
-# prior-checkpoint rows (no BQ regression).
+# prior-checkpoint rows (no regression).
 #
 # Disable this workflow once coverage reaches 100%.
 
@@ -2315,22 +2321,47 @@ jobs:
 
   # =====================================================================
   # MERGE JOB -- combine light (base) with modis / so2 / cloud / snet
-  # overlays, then snapshot / SSD mirror / coverage / checkpoint / Discord.
-  # Runs on RPi5 self-hosted runner so the merged DB lands on the ext4 SSD
-  # as primary storage. if: always() so single-job failure still reports.
+  # overlays, then snapshot / coverage / checkpoint / HF upload / Discord.
+  # 2026-05-28: migrated off the RPi5 self-hosted runner + USB SSD (both
+  # permanently retired after the SSD died) to ubuntu-latest. The merged
+  # DB is no longer mirrored to /mnt/ssd; instead the canonical durable
+  # copy lives on the Hugging Face dataset yasumorishima/japan-geohazard
+  # (uploaded once/day, see the HF step below). The GitHub artifact chain
+  # (backfill-checkpoint-<run_id>) remains the per-run working state.
+  # if: always() so single-job failure still reports.
   # =====================================================================
   merge:
     needs: [fetch-modis, fetch-so2, fetch-cloud, fetch-snet, fetch-hinet, light]
     if: always() && inputs.target != 'diagnostic'
-    runs-on: [self-hosted, Linux, ARM64, rpi5-geohazard]
+    runs-on: ubuntu-latest
     # Bumped 60->150 after Hi-net Stage 1 (PR #127) pushed merge time past
     # 60min ceiling (run 25276071313 / 25279499629 both cancelled at Snapshot
     # step). 150min matches fetch-snet/fetch-hinet/light heavy-job tier with
-    # comfortable headroom for ~10min merge + ~5min misc + SSD copy.
+    # comfortable headroom for ~10min merge + ~5min misc + HF upload.
     timeout-minutes: 150
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Free up runner disk and stage the large /mnt scratch
+        # merge_checkpoints.py copies the ~16.5GB base to the dst (shutil.copyfile),
+        # so the job holds ~33GB at once: base+overlays AND dst. Split them across
+        # filesystems so neither fills up:
+        #   - base + overlays -> /mnt/merge  (the ephemeral disk, ~74GB free)
+        #   - dst data/geohazard.db          (root fs, freed below, ~40GB)
+        # Reclaiming toolcaches we don't use here (Android SDK, .NET, GHC, CodeQL)
+        # gives the root fs comfortable headroom for the 16.5GB dst + snapshot.
+        run: |
+          df -h / /mnt
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost 2>/dev/null || true
+          sudo mkdir -p /mnt/merge
+          sudo chown "$(id -u):$(id -g)" /mnt/merge
+          df -h / /mnt
 
       - name: Download light.db artifact
         id: download_light
@@ -2338,7 +2369,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-light-${{ github.run_id }}
-          path: /mnt/ssd/runner-temp/light
+          path: /mnt/merge/light
 
       - name: Download modis.db artifact
         id: download_modis
@@ -2346,7 +2377,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-modis-${{ github.run_id }}
-          path: /mnt/ssd/runner-temp/modis
+          path: /mnt/merge/modis
 
       - name: Download so2.db artifact
         id: download_so2
@@ -2354,7 +2385,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-so2-${{ github.run_id }}
-          path: /mnt/ssd/runner-temp/so2
+          path: /mnt/merge/so2
 
       - name: Download cloud.db artifact
         id: download_cloud
@@ -2362,7 +2393,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-cloud-${{ github.run_id }}
-          path: /mnt/ssd/runner-temp/cloud
+          path: /mnt/merge/cloud
 
       - name: Download snet.db artifact
         id: download_snet
@@ -2370,7 +2401,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-snet-${{ github.run_id }}
-          path: /mnt/ssd/runner-temp/snet
+          path: /mnt/merge/snet
 
       - name: Download hinet.db artifact
         if: needs.fetch-hinet.result == 'success'
@@ -2378,22 +2409,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: backfill-hinet-${{ github.run_id }}
-          path: /mnt/ssd/runner-temp/hinet
+          path: /mnt/merge/hinet
 
       - name: Merge light + 4 overlays
         id: merge
         run: |
           mkdir -p data
-          # --require-base ensures we never let an overlay-only DB through to BQ
-          # (would WRITE_TRUNCATE every light-owned table and zero them out).
+          # --require-base ensures we never let an overlay-only DB through as a
+          # checkpoint (would zero out every light-owned table on the next run).
           python3 scripts/merge_checkpoints.py \
-            --base /mnt/ssd/runner-temp/light/geohazard.db \
-            --overlay /mnt/ssd/runner-temp/modis/geohazard.db:modis_lst \
-            --overlay /mnt/ssd/runner-temp/so2/geohazard.db:so2_column \
-            --overlay /mnt/ssd/runner-temp/cloud/geohazard.db:cloud_fraction \
-            --overlay /mnt/ssd/runner-temp/snet/geohazard.db:snet_waveform \
-            --overlay /mnt/ssd/runner-temp/snet/geohazard.db:fnet_waveform \
-            --overlay /mnt/ssd/runner-temp/hinet/geohazard.db:hinet_waveform \
+            --base /mnt/merge/light/geohazard.db \
+            --overlay /mnt/merge/modis/geohazard.db:modis_lst \
+            --overlay /mnt/merge/so2/geohazard.db:so2_column \
+            --overlay /mnt/merge/cloud/geohazard.db:cloud_fraction \
+            --overlay /mnt/merge/snet/geohazard.db:snet_waveform \
+            --overlay /mnt/merge/snet/geohazard.db:fnet_waveform \
+            --overlay /mnt/merge/hinet/geohazard.db:hinet_waveform \
             --dst data/geohazard.db \
             --require-base
 
@@ -2427,31 +2458,30 @@ jobs:
               sys.exit(1)
           "
 
-      - name: Mirror merged DB to RPi5 SSD (primary storage)
-        # Same gating as `Upload checkpoint artifact` below: never overwrite
-        # the SSD primary copy from a targeted workflow_dispatch (e.g.
-        # target=cloud) because that DB only contains fresh rows for one
-        # table and would roll back the other tables' state. The
-        # `github.ref == 'refs/heads/master'` clause additionally prevents
-        # a feature-branch workflow_dispatch (target=all or '') from
-        # overwriting the SSD primary; only master should write to it.
-        # `schedule` events always run on the default branch in GitHub
-        # Actions, so this clause does not block the production cron.
-        # Atomic-swap: stage to .new, retain previous as .prev (silenced on
-        # first run when no current file exists), then mv -f for atomic
-        # POSIX rename. SSD has 205GB free for the geohazard archive.
+      - name: Upload canonical DB to Hugging Face (durable primary storage)
+        # Replaces the retired RPi5 SSD mirror. The Hugging Face dataset
+        # yasumorishima/japan-geohazard is now the canonical durable copy.
+        # Gated to ONE cron tick per day (UTC 00:00) -- not every 3h run --
+        # because each push is a ~16.5GB git-LFS commit; uploading 8x/day
+        # would balloon the dataset's LFS storage. hf_sync.py squashes LFS
+        # history after a verified upload to keep usedStorage bounded.
+        # schedule-only + master-only: a targeted/feature-branch dispatch
+        # carries a partial DB and must never overwrite the canonical copy.
+        # To push manually, use the hf-upload-checkpoint.yml workflow.
         if: >-
           steps.snapshot.outcome == 'success'
           && github.ref == 'refs/heads/master'
-          && (github.event_name != 'workflow_dispatch'
-              || inputs.target == 'all'
-              || inputs.target == '')
+          && github.event_name == 'schedule'
+          && github.event.schedule == '0 0 * * *'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          mkdir -p /mnt/ssd/geohazard
-          cp data/geohazard.db /mnt/ssd/geohazard/geohazard.db.new
-          cp /mnt/ssd/geohazard/geohazard.db /mnt/ssd/geohazard/geohazard.db.prev 2>/dev/null || true
-          mv -f /mnt/ssd/geohazard/geohazard.db.new /mnt/ssd/geohazard/geohazard.db
-          ls -lh /mnt/ssd/geohazard/
+          pip install --quiet "huggingface_hub>=0.26"
+          python3 scripts/hf_sync.py \
+            --src data/geohazard.db \
+            --repo yasumorishima/japan-geohazard \
+            --path geohazard.db \
+            --squash
 
       - name: Coverage report
         if: steps.snapshot.outcome == 'success'

--- a/.github/workflows/reseed-checkpoint-from-hf.yml
+++ b/.github/workflows/reseed-checkpoint-from-hf.yml
@@ -1,0 +1,59 @@
+name: Reseed checkpoint from Hugging Face
+
+# One-shot recovery: pull the canonical geohazard.db from the Hugging Face
+# dataset and re-publish it as a fresh backfill-checkpoint-<run_id> artifact.
+#
+# Why: after the RPi5 SSD died (2026-05-27) the GitHub artifact chain's latest
+# surviving checkpoint was a degraded ~587MB salvage, while the full ~16.5GB
+# history lives only on HF. Running this once puts a complete checkpoint back
+# at the head of the chain (newest created_at), so the normal backfill restore
+# step (sort_by(created_at)|reverse) picks it up and the pipeline resumes from
+# full history instead of the degraded remnant.
+#
+# Run manually whenever the artifact chain needs reseeding from HF.
+
+on:
+  workflow_dispatch:
+    inputs:
+      memo:
+        description: 'Why this reseed'
+        required: true
+
+jobs:
+  reseed:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Free up runner disk for the 16.5GB DB
+        run: |
+          df -h /
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost 2>/dev/null || true
+          df -h /
+
+      - name: Download canonical DB from Hugging Face
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          pip install --quiet "huggingface_hub>=0.26"
+          mkdir -p data
+          hf download yasumorishima/japan-geohazard geohazard.db \
+            --repo-type dataset --local-dir data
+          ls -lh data/geohazard.db
+
+      - name: Integrity check
+        run: |
+          python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+
+      - name: Upload as fresh checkpoint artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backfill-checkpoint-${{ github.run_id }}
+          path: data/geohazard.db
+          retention-days: 30

--- a/scripts/hf_sync.py
+++ b/scripts/hf_sync.py
@@ -7,7 +7,13 @@ database; the GitHub artifact chain remains the per-run working state.
 Safeguards:
     1. The source DB must pass PRAGMA integrity_check before any upload, so a
        corrupt/partial merge can never overwrite the canonical copy.
-    2. --squash runs HfApi.super_squash_history AFTER a verified upload, folding
+    2. No-shrink guard: backfill only ever adds rows, so the DB grows
+       monotonically. If the source is smaller than --min-fraction of the
+       current remote file, refuse the upload. This protects the canonical
+       copy from a degraded/partial merge (e.g. a run that built on a salvaged
+       checkpoint) silently overwriting -- and then squashing away -- the full
+       history. A first upload (no remote file yet) skips this check.
+    3. --squash runs HfApi.super_squash_history AFTER a verified upload, folding
        the git-LFS history into a single commit. Each push is a ~16.5GB LFS
        commit, so without squashing the dataset's usedStorage grows unbounded.
        Squash is only reached once the upload has returned successfully.
@@ -19,8 +25,27 @@ Exit 0 on success, Exit 1 on integrity failure or upload error.
 """
 
 import argparse
+import os
 import sqlite3
 import sys
+
+
+def remote_size(repo: str, path: str):
+    """Size in bytes of `path` in the HF dataset, or None if not present yet."""
+    from huggingface_hub import HfApi
+
+    try:
+        info = HfApi().get_paths_info(repo, [path], repo_type="dataset")
+    except Exception as e:  # noqa: BLE001 - treat as "unknown", caller decides
+        print(f"  could not read remote size ({e})")
+        return None
+    if not info:
+        return None
+    obj = info[0]
+    lfs = getattr(obj, "lfs", None)
+    if lfs is not None and getattr(lfs, "size", None) is not None:
+        return lfs.size
+    return getattr(obj, "size", None)
 
 
 def integrity_ok(path: str) -> bool:
@@ -56,6 +81,13 @@ def main() -> int:
         action="store_true",
         help="fold LFS history into one commit after a verified upload",
     )
+    p.add_argument(
+        "--min-fraction",
+        type=float,
+        default=0.95,
+        help="refuse upload if src is smaller than this fraction of the remote "
+        "file (no-shrink guard; backfill grows monotonically). 0 disables.",
+    )
     args = p.parse_args()
 
     # Fail closed: never push a DB that does not pass integrity_check.
@@ -63,6 +95,26 @@ def main() -> int:
     if not integrity_ok(args.src):
         print("::error::refusing to upload -- source DB failed integrity_check")
         return 1
+
+    # No-shrink guard: a smaller-than-remote DB means a degraded/partial merge.
+    if args.min_fraction > 0:
+        local_bytes = os.path.getsize(args.src)
+        remote_bytes = remote_size(args.repo, args.path)
+        if remote_bytes is None:
+            print("  no existing remote file (or size unknown) -- skipping shrink guard")
+        else:
+            floor = remote_bytes * args.min_fraction
+            print(
+                f"  local={local_bytes:,}B remote={remote_bytes:,}B "
+                f"floor={floor:,.0f}B (min-fraction={args.min_fraction})"
+            )
+            if local_bytes < floor:
+                print(
+                    "::error::refusing to upload -- source DB is smaller than "
+                    f"{args.min_fraction:.0%} of the remote canonical copy "
+                    "(likely a degraded/partial merge)"
+                )
+                return 1
 
     from huggingface_hub import HfApi
 

--- a/scripts/hf_sync.py
+++ b/scripts/hf_sync.py
@@ -1,0 +1,91 @@
+"""Upload the canonical geohazard.db to a Hugging Face dataset.
+
+This replaces the retired RPi5 USB SSD primary tier. The Hugging Face dataset
+yasumorishima/japan-geohazard is now the canonical durable copy of the merged
+database; the GitHub artifact chain remains the per-run working state.
+
+Safeguards:
+    1. The source DB must pass PRAGMA integrity_check before any upload, so a
+       corrupt/partial merge can never overwrite the canonical copy.
+    2. --squash runs HfApi.super_squash_history AFTER a verified upload, folding
+       the git-LFS history into a single commit. Each push is a ~16.5GB LFS
+       commit, so without squashing the dataset's usedStorage grows unbounded.
+       Squash is only reached once the upload has returned successfully.
+
+HF_TOKEN is read from the environment by huggingface_hub automatically (same as
+.github/workflows/hf-upload-checkpoint.yml).
+
+Exit 0 on success, Exit 1 on integrity failure or upload error.
+"""
+
+import argparse
+import sqlite3
+import sys
+
+
+def integrity_ok(path: str) -> bool:
+    """Full PRAGMA integrity_check. Returns True only on 'ok'."""
+    try:
+        conn = sqlite3.connect(path)
+    except Exception as e:  # noqa: BLE001 - report and fail closed
+        print(f"  DB open failed: {e}")
+        return False
+    try:
+        r = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        if r != "ok":
+            print(f"  integrity_check FAILED: {r[:200]}")
+            return False
+        print("  integrity_check OK")
+        return True
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Upload geohazard.db to Hugging Face")
+    p.add_argument("--src", required=True, help="local DB path")
+    p.add_argument("--repo", required=True, help="HF dataset repo id (owner/name)")
+    p.add_argument("--path", default="geohazard.db", help="path within the repo")
+    p.add_argument(
+        "--message",
+        default="Update geohazard.db (backfill checkpoint)",
+        help="commit message",
+    )
+    p.add_argument(
+        "--squash",
+        action="store_true",
+        help="fold LFS history into one commit after a verified upload",
+    )
+    args = p.parse_args()
+
+    # Fail closed: never push a DB that does not pass integrity_check.
+    print(f"Verifying {args.src} before upload...")
+    if not integrity_ok(args.src):
+        print("::error::refusing to upload -- source DB failed integrity_check")
+        return 1
+
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    print(f"Uploading {args.src} -> {args.repo}:{args.path} ...")
+    api.upload_file(
+        path_or_fileobj=args.src,
+        path_in_repo=args.path,
+        repo_id=args.repo,
+        repo_type="dataset",
+        commit_message=args.message,
+    )
+    print("Upload complete.")
+
+    if args.squash:
+        # Only reached after a successful upload above, so the canonical copy
+        # is safely committed before history is collapsed (irreversible).
+        print("Squashing LFS history to bound usedStorage...")
+        api.super_squash_history(repo_id=args.repo, repo_type="dataset")
+        print("History squashed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The RPi5 self-hosted runner and its USB SSD primary tier died permanently on 2026-05-27 and will not be rebuilt (microSD-only operation from here on). The `merge` job was the **only** job still bound to them, so every scheduled `Backfill Data` run has been stuck `pending` on an offline runner since the outage. Data is safe — the full 16.5GB `geohazard.db` lives on the public HF dataset [`yasumorishima/japan-geohazard`](https://huggingface.co/datasets/yasumorishima/japan-geohazard).

## What

- **merge job to `ubuntu-latest`** (was `[self-hosted, Linux, ARM64, rpi5-geohazard]`).
- Scratch artifacts download to **`/mnt/merge`** (ephemeral disk, ~74GB) while the merged `dst` stays on the root fs, splitting the ~33GB peak (`merge_checkpoints.py` copies base into dst) across two filesystems. Unused toolcaches reclaimed for headroom.
- The `/mnt/ssd` mirror step is replaced by an **upload to Hugging Face** (now the canonical durable store), via new `scripts/hf_sync.py`. Gated to the **UTC 00:00 cron only** (one ~16.5GB LFS commit/day) and `super_squash_history` keeps usedStorage bounded.
- The **GitHub artifact chain** (`backfill-checkpoint-<run_id>`, retention 30d) is unchanged — still the per-run working state restored by each fetch job (GitHub-internal, free).

### Safety
- `hf_sync.py` is **integrity-gated** (refuses a DB failing `PRAGMA integrity_check`) and has a **no-shrink guard** (refuses a DB smaller than 95% of the remote, so a degraded/partial merge cannot overwrite then squash away the canonical history).
- HF upload is `schedule`-only and `master`-only, so a targeted/feature-branch dispatch (partial DB) never touches the canonical copy.

### New files
- `scripts/hf_sync.py` — integrity + no-shrink gated HF upload, optional LFS squash.
- `.github/workflows/reseed-checkpoint-from-hf.yml` — one-shot to pull the 16.5GB canonical DB from HF back into a fresh checkpoint artifact (the surviving chain head was a degraded ~587MB salvage after the outage).

## Rollout (after merge)
1. Run **Reseed checkpoint from Hugging Face** to put a full 16.5GB checkpoint at the chain head.
2. Confirm the reseed artifact is ~16.5GB.
3. Let the cron resume; the first full run builds on the reseeded checkpoint.

## To verify on first real run
`merge_checkpoints.py` holds base + dst (~33GB) at once. The `Free up runner disk` step plus the `/mnt` split should cover it, but the `df -h / /mnt` output in the merge job must be checked on the first full-scale (16.5GB) run. The pre-reseed degraded chain (~587MB) does not exercise the 33GB path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual workflow to reseed checkpoint data from Hugging Face
  * Database uploads now include integrity verification and size safeguards

* **Chores**
  * Updated merge workflow infrastructure with improved artifact handling
  * Configured primary database storage to Hugging Face with daily synchronization
  * Enhanced runner resource management with automated cleanup routines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->