### PR TITLE
fix(backfill): extend Restore step timeouts for 17GB checkpoint (re-seeded chain head)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -245,7 +245,7 @@ jobs:
               rm -f data/geohazard.db-wal data/geohazard.db-shm
               DB_SIZE=$(du -h data/geohazard.db | cut -f1)
               log "  copied (${DB_SIZE}) -- checking integrity"
-              timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
               if [ $ic_rc -eq 0 ]; then
                 RESTORED="${ARTIFACT_NAME}"
@@ -254,7 +254,7 @@ jobs:
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
-                timeout 600 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
+                timeout 1800 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
                 sv_rc=$?
                 if [ $sv_rc -eq 0 ] && [ -f /tmp/salvaged.db ]; then
                   rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
@@ -446,7 +446,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -533,7 +533,7 @@ jobs:
               rm -f data/geohazard.db-wal data/geohazard.db-shm
               DB_SIZE=$(du -h data/geohazard.db | cut -f1)
               log "  copied (${DB_SIZE}) -- checking integrity"
-              timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
               if [ $ic_rc -eq 0 ]; then
                 RESTORED="${ARTIFACT_NAME}"
@@ -542,7 +542,7 @@ jobs:
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
-                timeout 600 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
+                timeout 1800 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
                 sv_rc=$?
                 if [ $sv_rc -eq 0 ] && [ -f /tmp/salvaged.db ]; then
                   rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
@@ -753,7 +753,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -840,7 +840,7 @@ jobs:
               rm -f data/geohazard.db-wal data/geohazard.db-shm
               DB_SIZE=$(du -h data/geohazard.db | cut -f1)
               log "  copied (${DB_SIZE}) -- checking integrity"
-              timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
               if [ $ic_rc -eq 0 ]; then
                 RESTORED="${ARTIFACT_NAME}"
@@ -849,7 +849,7 @@ jobs:
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
-                timeout 600 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
+                timeout 1800 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
                 sv_rc=$?
                 if [ $sv_rc -eq 0 ] && [ -f /tmp/salvaged.db ]; then
                   rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
@@ -1058,7 +1058,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -1145,7 +1145,7 @@ jobs:
               rm -f data/geohazard.db-wal data/geohazard.db-shm
               DB_SIZE=$(du -h data/geohazard.db | cut -f1)
               log "  copied (${DB_SIZE}) -- checking integrity"
-              timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
               if [ $ic_rc -eq 0 ]; then
                 RESTORED="${ARTIFACT_NAME}"
@@ -1154,7 +1154,7 @@ jobs:
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
-                timeout 600 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
+                timeout 1800 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
                 sv_rc=$?
                 if [ $sv_rc -eq 0 ] && [ -f /tmp/salvaged.db ]; then
                   rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
@@ -1400,7 +1400,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -1485,7 +1485,7 @@ jobs:
               rm -f data/geohazard.db-wal data/geohazard.db-shm
               DB_SIZE=$(du -h data/geohazard.db | cut -f1)
               log "  copied (${DB_SIZE}) -- checking integrity"
-              timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
               if [ $ic_rc -eq 0 ]; then
                 RESTORED="${ARTIFACT_NAME}"
@@ -1494,7 +1494,7 @@ jobs:
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
-                timeout 600 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
+                timeout 1800 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
                 sv_rc=$?
                 if [ $sv_rc -eq 0 ] && [ -f /tmp/salvaged.db ]; then
                   rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
@@ -1750,7 +1750,7 @@ jobs:
       - name: Restore previous database checkpoint
         id: restore
         continue-on-error: true
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash {0}
@@ -1837,7 +1837,7 @@ jobs:
               rm -f data/geohazard.db-wal data/geohazard.db-shm
               DB_SIZE=$(du -h data/geohazard.db | cut -f1)
               log "  copied (${DB_SIZE}) -- checking integrity"
-              timeout 300 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
               if [ $ic_rc -eq 0 ]; then
                 RESTORED="${ARTIFACT_NAME}"
@@ -1846,7 +1846,7 @@ jobs:
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
-                timeout 600 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
+                timeout 1800 python3 scripts/salvage_db.py --src data/geohazard.db --dst /tmp/salvaged.db
                 sv_rc=$?
                 if [ $sv_rc -eq 0 ] && [ -f /tmp/salvaged.db ]; then
                   rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm


### PR DESCRIPTION
## Why

The first full schedule cron after the PR #166 cutover (run 26567450670, 2026-05-28 09:48 UTC) succeeded at the workflow level but produced a **degraded checkpoint**, dropping these tables vs the reseeded baseline:

| Table | Before (reseed) | After this run | Loss |
|---|---:|---:|---|
| ulf_magnetic | 19.44M (2014-01 → 2026-05) | 2.59M (2024-10 → 2026-05) | **−86.7%** |
| so2_column | 19.64M (2004-10 → 2025-06) | 4.54M (2011-01 → 2016-06) | **−77%** |
| ioc_sea_level | 53.78M (2011-01 → 2016-03) | 21.07M (2011-01 → 2013-08) | **−60.8%** |

Same shape as the **PR #153** regression. PR #166 reseeded the chain head to the full 16.5 GB HF DB (17 G uncompressed). At this size `PRAGMA quick_check` empirically takes ~6 minutes (measured during the reseed run: 00:11:11 to 00:17:13), but the Restore step's `check_db_integrity.py --mode=quick` was still wrapped in `timeout 300` (5 min) from PR #153, which had been calibrated for the 14-15 GB regime.

light job evidence (run 26567450670):
```
10:18:19 trying backfill-checkpoint-26546306912 (reseed 17G)
10:21:09 copied (17G), checking integrity
10:26:09 corrupted (rc=124)  ← timeout 300 fired
10:36:09 salvage failed (rc=124)  ← timeout 600 fired
10:36:10 fallback to backfill-checkpoint-25921630816 (587MB May-15 salvage)
10:36:41 Restored from backfill-checkpoint-25921630816  ← degraded base accepted
```

All 6 fetch jobs hit the same timeout pattern in parallel, so merge ran with a degraded base (and its own degraded overlays for so2). The shrunk checkpoint then propagated to the chain head as `backfill-checkpoint-26567450670` (905 MB).

## What

Uniformly raise the three Restore step timeouts across all 6 fetch jobs:

- `timeout 300 check_db_integrity.py --mode=quick` → `timeout 1200` (4× safety over observed 6 min ceiling)
- `timeout 600 salvage_db.py` → `timeout 1800` (proportional, rarely reached when quick passes)
- step-level `timeout-minutes: 60` → `90` (allows one full quick + buffer)

18 numeric replacements across the 6 fetch jobs, zero logic changes.

## Rollout

1. Merge this PR.
2. Re-run **Reseed checkpoint from Hugging Face** to put a fresh 17 GB checkpoint at the chain head. The degraded `backfill-checkpoint-26567450670` will be superseded by `created_at`.
3. The next schedule cron picks up the new checkpoint with the raised timeouts and produces a clean full-size checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of database checkpoint restoration processes by extending operation timeouts and increasing time limits for database integrity verification and recovery operations across multiple data fetch jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->