### PR TITLE
ci(backfill): add Free disk space step to so2/modis/cloud/snet/hinet fetch jobs

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -144,6 +144,16 @@ jobs:
       restore_restored: ${{ steps.restore.outputs.restored }}
 
     steps:
+      # Free ~30GB of pre-installed software we never use. The 2026-05-28
+      # 15:00 UTC full-schedule run hit "no space left on device" while
+      # expanding the 17GB checkpoint into /tmp/db-restore; so2/modis/cloud/
+      # hinet all failed at the Restore step. The light job already does this
+      # and was the only fetch job to survive. Mirror that mitigation here.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
@@ -432,6 +442,16 @@ jobs:
       restore_restored: ${{ steps.restore.outputs.restored }}
 
     steps:
+      # Free ~30GB of pre-installed software we never use. The 2026-05-28
+      # 15:00 UTC full-schedule run hit "no space left on device" while
+      # expanding the 17GB checkpoint into /tmp/db-restore; so2/modis/cloud/
+      # hinet all failed at the Restore step. The light job already does this
+      # and was the only fetch job to survive. Mirror that mitigation here.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
@@ -738,6 +758,16 @@ jobs:
       restore_restored: ${{ steps.restore.outputs.restored }}
 
     steps:
+      # Free ~30GB of pre-installed software we never use. The 2026-05-28
+      # 15:00 UTC full-schedule run hit "no space left on device" while
+      # expanding the 17GB checkpoint into /tmp/db-restore; so2/modis/cloud/
+      # hinet all failed at the Restore step. The light job already does this
+      # and was the only fetch job to survive. Mirror that mitigation here.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
@@ -1044,6 +1074,16 @@ jobs:
       restore_restored: ${{ steps.restore.outputs.restored }}
 
     steps:
+      # Free ~30GB of pre-installed software we never use. The 2026-05-28
+      # 15:00 UTC full-schedule run hit "no space left on device" while
+      # expanding the 17GB checkpoint into /tmp/db-restore; so2/modis/cloud/
+      # hinet all failed at the Restore step. The light job already does this
+      # and was the only fetch job to survive. Mirror that mitigation here.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
@@ -1389,6 +1429,16 @@ jobs:
       restore_outcome: ${{ steps.restore.outcome }}
       restore_restored: ${{ steps.restore.outputs.restored }}
     steps:
+      # Free ~30GB of pre-installed software we never use. The 2026-05-28
+      # 15:00 UTC full-schedule run hit "no space left on device" while
+      # expanding the 17GB checkpoint into /tmp/db-restore; so2/modis/cloud/
+      # hinet all failed at the Restore step. The light job already does this
+      # and was the only fetch job to survive. Mirror that mitigation here.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## 背景

2026-05-28 15:00 UTC の full-schedule cron (run `26585020487`) で、PR #168 の timeout 拡張により Restore step は全 job 成功したものの、17GB checkpoint を `/tmp/db-restore` へ展開する際に 4 job (`fetch-so2` / `fetch-modis` / `fetch-cloud` / `fetch-hinet`) が `no space left on device` で failure。merge も連鎖 fail した。

成功した `light` job だけが steps 先頭に `Free disk space` step (dotnet/android/ghc/codeql 削除で ~30GB 回収) を持っていたことが真因。

## 変更

`fetch-so2` / `fetch-modis` / `fetch-cloud` / `fetch-snet` / `fetch-hinet` の 5 fetch job の `steps:` 先頭 (checkout 前) に、`light` job と同一の `Free disk space` step を追加。

```yaml
      - name: Free disk space
        run: |
          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
          df -h
```

- 挿入 5 箇所、`Free disk space` step が 1 → 6 に
- `merge` job は既に独自の disk 解放 step を持つため対象外
- `diagnostic-cloud` は重い fetch なしのため対象外

次 cron で disk-full 解消を検証予定。
