### PR TITLE
fix(backfill): cloud snapshot CLI verify uses quick_check, not integrity_check

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1004,10 +1004,17 @@ jobs:
               # cache / writer-side view. Force flush + fresh subprocess +
               # SELECT COUNT on the populated table catches the real state.
               os.sync()
+              # Use quick_check here (the full structural integrity_check is
+              # already done unbounded by the Python src check above). On the
+              # ~17GB DB the CLI integrity_check exceeded the 600s cap (run
+              # 26599363437), failing the snapshot and silently dropping the
+              # cloud overlay, so cloud_fraction stayed 0. quick_check + the
+              # COUNT(*) keep the fresh-process on-disk verify fast/predictable
+              # while still catching page/truncation corruption.
               r2 = subprocess.run(
                   ['sqlite3', 'data/geohazard_snapshot.db',
-                   'PRAGMA integrity_check;\nSELECT COUNT(*) FROM cloud_fraction;'],
-                  capture_output=True, text=True, timeout=600
+                   'PRAGMA quick_check;\nSELECT COUNT(*) FROM cloud_fraction;'],
+                  capture_output=True, text=True, timeout=1200
               )
               first = (r2.stdout.strip().split('\n')[0] if r2.stdout.strip() else '').strip()
               if r2.returncode != 0 or first != 'ok':


### PR DESCRIPTION
## 真因

`fetch-cloud` job の **Snapshot DB step** は `integrity_check` を2回走らせている:

1. Python `src.execute('PRAGMA integrity_check')` — timeout 無し（job 150分まで許容）→ **通過**
2. backup 後の `subprocess.run(['sqlite3', snapshot, 'PRAGMA integrity_check; SELECT COUNT(*) FROM cloud_fraction'], timeout=600)` — **600s で timeout** → snapshot 失敗 → overlay upload skip

DB が ~17GB（ioc 59.5M + so2 19.6M + ulf 22M 行…）に肥大し、cold な snapshot コピーへの CLI `integrity_check` が 600s を超えるようになったのが真因。fetch 自体は成功（600,141 records / 30ヶ月）しているのに②で死に、**cloud_fraction が 0 のまま**だった（run `26599363437` で確認）。

## 修正

②の CLI verify を `integrity_check` → **`quick_check`** に変更（timeout 600→1200）。

- full structural check は①の Python `integrity_check`（unbounded・通過）が担保するため rigor は不変
- ②の付加価値である「fresh subprocess での on-disk 状態の COUNT(*) 読み出し」はそのまま維持（truncation/page corruption を検出）
- `quick_check` は Restore step で既に採用済みの確立パターン（PR #153/#154）で高速・予測可能

これで次回 cloud fetch から cloud_fraction が埋まり始める見込み。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved snapshot backup verification process with enhanced database validation checks and extended timeout duration for increased reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->