### PR TITLE
ci(backfill): serialise master workflow_dispatch with the schedule cron

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -108,16 +108,19 @@ permissions:
 # light restore step hanging when a prior run overlapped). cancel-in-progress
 # is deliberately false so a long-running run isn't killed by the next
 # schedule tick; the next run queues until this one finishes.
-# Scope: schedule (master cron) shares one queue ("backfill-data-master")
-# to serialise the production pipeline. workflow_dispatch on a feature
-# branch gets its own ref-scoped queue so PR smoke runs don't fight the
-# master cron (2026-05-11: PR #157 smoke was evicted by a fresh schedule
-# tick before this change). Data isolation between branch dispatches and
+# Scope: anything running on master -- schedule (cron) AND manual
+# workflow_dispatch (e.g. target=all) -- shares one queue
+# ("backfill-data-master") so they serialise the production pipeline and
+# never run concurrently building checkpoints on a stale base (2026-05-29:
+# a master target=all dispatch ran alongside the cron and the two runs did
+# not compound). Only a dispatch on a NON-master (feature) branch gets its
+# own ref-scoped queue so PR smoke runs don't fight the master cron
+# (2026-05-11: PR #157 smoke was evicted by a fresh schedule tick). Data isolation between branch dispatches and
 # master is already enforced by the SSD-mirror / artifact-upload gates
 # below, so the only thing the shared queue was protecting was the
 # artifact API, and the schedule-only sub-queue is sufficient for that.
 concurrency:
-  group: backfill-data-${{ github.event_name == 'schedule' && 'master' || github.ref }}
+  group: backfill-data-${{ github.ref == 'refs/heads/master' && 'master' || github.ref }}
   cancel-in-progress: false
 
 # Reusable shell snippets are inlined per job below; YAML anchors aren't


### PR DESCRIPTION
## 問題

concurrency group が `github.event_name == 'schedule'` で分岐していたため:

| 起動 | group |
|---|---|
| schedule (cron) | `backfill-data-master` |
| **master の手動 dispatch** (target=all) | `backfill-data-refs/heads/master` |

2つは別 group なので**直列化されず同時実行され得る**。実際 2026-05-29 に master dispatch `26611195476` と schedule `26614399138` が並走。各 run が自分の Restore 時点の base から進むため、**連投しても compound しない**（merge の integrity_check は fail-closed なので chain 破損はしないが、無駄打ちになる）。

## 修正

group の分岐キーを `github.event_name` → **`github.ref`** に変更:

```yaml
group: backfill-data-${{ github.ref == 'refs/heads/master' && 'master' || github.ref }}
```

| 起動 | group | 効果 |
|---|---|---|
| schedule (常に master) | `backfill-data-master` | 不変 |
| master の手動 dispatch | `backfill-data-master` | **cron と直列化**（連投が compound する） |
| feature branch の dispatch | `backfill-data-refs/heads/<branch>` | 不変（PR smoke が cron と喧嘩しない既存意図を維持） |

これで「public repo 無料無制限を活かして target=all を連投し漸進を安全に加速」が可能になる。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow concurrency logic to improve queue management for master branch runs, ensuring consistent handling across both scheduled and manual workflow triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->