### PR TITLE
ci(backfill): reclaim more runner disk in fetch jobs so the Snapshot backup fits

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -154,7 +154,8 @@ jobs:
       # and was the only fetch job to survive. Mirror that mitigation here.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/share/swift /usr/local/.ghcup /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
           df -h
 
       - uses: actions/checkout@v4
@@ -452,7 +453,8 @@ jobs:
       # and was the only fetch job to survive. Mirror that mitigation here.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/share/swift /usr/local/.ghcup /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
           df -h
 
       - uses: actions/checkout@v4
@@ -768,7 +770,8 @@ jobs:
       # and was the only fetch job to survive. Mirror that mitigation here.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/share/swift /usr/local/.ghcup /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
           df -h
 
       - uses: actions/checkout@v4
@@ -1091,7 +1094,8 @@ jobs:
       # and was the only fetch job to survive. Mirror that mitigation here.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/share/swift /usr/local/.ghcup /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
           df -h
 
       - uses: actions/checkout@v4
@@ -1446,7 +1450,8 @@ jobs:
       # and was the only fetch job to survive. Mirror that mitigation here.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/share/swift /usr/local/.ghcup /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
           df -h
 
       - uses: actions/checkout@v4
@@ -1793,7 +1798,8 @@ jobs:
       # of them.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache /usr/share/swift /usr/local/.ghcup /usr/local/share/boost 2>/dev/null || true
+          sudo docker image prune -af 2>/dev/null || true
           df -h
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 問題

fetch job の **Snapshot DB step** は `src.backup(dst)` で working DB（~17GB）の **2つ目のコピー**を root fs に作るため、ピークで ~34GB を保持する。cloud_fraction backfill で DB が肥大し、freed-root の上限（~40GB）を超えて Snapshot が `database or disk is full` で散発失敗するようになった（light + so2、runs `26636879497` / `26644279362`、failure率 1/6→2/6、cloud が 2018-05 で3 run 停滞）。chain は fail-closed で無傷だが、DB 成長で悪化する。

## 修正（応急）

各 fetch job の既存 disk 解放 step に未使用 toolcache を追加（full `/opt/hostedtoolcache` + swift + ghcup + boost + docker images、~+14GB）。これで2コピーが収まる。

- `/opt/hostedtoolcache` は free-disk step（最初の step）で削除 → 後続 `setup-python@v5` が Python を再取得するだけで無害
- merge job の解放 step は別構成（/mnt ステージ込み）なので非対象

## 注記（durable fix は別途）

恒久対応は merge job 同様 **snapshot を `/mnt`（~74GB ephemeral）へ退避**して root fs に1コピーだけにすること（DB がさらに成長しても破綻しない）。これは6つの snapshot ブロックの編集を伴うため別 PR で提案予定。本 PR は cloud→2026 充填に十分な runway を確保する応急。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow disk cleanup procedures to improve resource management during automated builds across multiple jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->