### PR TITLE
fix(snapshot): write snapshot + VACUUM temp to /mnt scratch to fix root-fs disk-full blocking merge

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -354,6 +354,7 @@ jobs:
           try:
               subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
               subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
+              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -673,6 +674,7 @@ jobs:
           try:
               subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
               subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
+              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -997,6 +999,7 @@ jobs:
           try:
               subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
               subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
+              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -1355,6 +1358,7 @@ jobs:
           try:
               subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
               subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
+              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -1682,6 +1686,7 @@ jobs:
           try:
               subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
               subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
+              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -2333,6 +2338,7 @@ jobs:
           try:
               subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
               subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
+              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -345,13 +345,15 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import sqlite3, sys, os, struct
+          import sqlite3, sys, os, struct, subprocess
           def rm_sidefiles(base):
               for ext in ('-wal', '-shm'):
                   p = base + ext
                   if os.path.exists(p):
                       os.unlink(p)
           try:
+              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
+              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -360,10 +362,10 @@ jobs:
                   src.close()
                   sys.exit(1)
               # Pre-clean any stale snapshot side-files
-              for p in ('data/geohazard_snapshot.db', 'data/geohazard_snapshot.db-wal', 'data/geohazard_snapshot.db-shm'):
+              for p in ('/mnt/snap/geohazard_snapshot.db', '/mnt/snap/geohazard_snapshot.db-wal', '/mnt/snap/geohazard_snapshot.db-shm'):
                   if os.path.exists(p):
                       os.unlink(p)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
+              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               src.backup(dst)
               # Force DELETE journal_mode on dst BEFORE close so the header
               # WAL flag (inherited from src via backup) is rewritten. Without
@@ -375,23 +377,23 @@ jobs:
               dst.execute('VACUUM')
               dst.close()
               src.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
-              verify = sqlite3.connect('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
+              verify = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               verify.execute('PRAGMA journal_mode = DELETE')
               r2 = verify.execute('PRAGMA integrity_check').fetchone()[0]
               verify.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
               if r2 != 'ok':
                   print(f'REFUSING to upload corrupt snapshot (post-backup): {r2[:200]}')
                   sys.exit(1)
               # Defense-in-depth: header.page_count * page_size must equal file size
-              with open('data/geohazard_snapshot.db', 'rb') as f:
+              with open('/mnt/snap/geohazard_snapshot.db', 'rb') as f:
                   hdr = f.read(100)
               ps_raw = struct.unpack('>H', hdr[16:18])[0]
               page_size = 65536 if ps_raw == 1 else ps_raw
               page_count = struct.unpack('>I', hdr[28:32])[0]
               expected = page_count * page_size
-              actual = os.path.getsize('data/geohazard_snapshot.db')
+              actual = os.path.getsize('/mnt/snap/geohazard_snapshot.db')
               if actual != expected:
                   print(f'REFUSING to upload size-mismatched snapshot: header={expected} actual={actual} extra={actual-expected}')
                   sys.exit(1)
@@ -400,8 +402,8 @@ jobs:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
+          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
+            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
             # Strip stale WAL/SHM that mv preserved (it only renames .db).
             # If old data/geohazard.db-wal survives, a subsequent SQLite open
             # would re-apply those frames to the snapshot, re-introducing
@@ -662,13 +664,15 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import sqlite3, sys, os, struct
+          import sqlite3, sys, os, struct, subprocess
           def rm_sidefiles(base):
               for ext in ('-wal', '-shm'):
                   p = base + ext
                   if os.path.exists(p):
                       os.unlink(p)
           try:
+              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
+              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -677,10 +681,10 @@ jobs:
                   src.close()
                   sys.exit(1)
               # Pre-clean any stale snapshot side-files
-              for p in ('data/geohazard_snapshot.db', 'data/geohazard_snapshot.db-wal', 'data/geohazard_snapshot.db-shm'):
+              for p in ('/mnt/snap/geohazard_snapshot.db', '/mnt/snap/geohazard_snapshot.db-wal', '/mnt/snap/geohazard_snapshot.db-shm'):
                   if os.path.exists(p):
                       os.unlink(p)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
+              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               src.backup(dst)
               # Force DELETE journal_mode on dst BEFORE close so the header
               # WAL flag (inherited from src via backup) is rewritten. Without
@@ -692,23 +696,23 @@ jobs:
               dst.execute('VACUUM')
               dst.close()
               src.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
-              verify = sqlite3.connect('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
+              verify = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               verify.execute('PRAGMA journal_mode = DELETE')
               r2 = verify.execute('PRAGMA integrity_check').fetchone()[0]
               verify.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
               if r2 != 'ok':
                   print(f'REFUSING to upload corrupt snapshot (post-backup): {r2[:200]}')
                   sys.exit(1)
               # Defense-in-depth: header.page_count * page_size must equal file size
-              with open('data/geohazard_snapshot.db', 'rb') as f:
+              with open('/mnt/snap/geohazard_snapshot.db', 'rb') as f:
                   hdr = f.read(100)
               ps_raw = struct.unpack('>H', hdr[16:18])[0]
               page_size = 65536 if ps_raw == 1 else ps_raw
               page_count = struct.unpack('>I', hdr[28:32])[0]
               expected = page_count * page_size
-              actual = os.path.getsize('data/geohazard_snapshot.db')
+              actual = os.path.getsize('/mnt/snap/geohazard_snapshot.db')
               if actual != expected:
                   print(f'REFUSING to upload size-mismatched snapshot: header={expected} actual={actual} extra={actual-expected}')
                   sys.exit(1)
@@ -717,8 +721,8 @@ jobs:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
+          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
+            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
             # Strip stale WAL/SHM that mv preserved (it only renames .db).
             # If old data/geohazard.db-wal survives, a subsequent SQLite open
             # would re-apply those frames to the snapshot, re-introducing
@@ -991,6 +995,8 @@ jobs:
           python3 -c "
           import sqlite3, sys, os, subprocess
           try:
+              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
+              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -998,7 +1004,7 @@ jobs:
                   print(f'REFUSING to snapshot corrupt DB: {r[:200]}')
                   src.close()
                   sys.exit(1)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
+              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               src.backup(dst)
               dst.close()
               src.close()
@@ -1018,7 +1024,7 @@ jobs:
               # COUNT(*) keep the fresh-process on-disk verify fast/predictable
               # while still catching page/truncation corruption.
               r2 = subprocess.run(
-                  ['sqlite3', 'data/geohazard_snapshot.db',
+                  ['sqlite3', '/mnt/snap/geohazard_snapshot.db',
                    'PRAGMA quick_check;\nSELECT COUNT(*) FROM cloud_fraction;'],
                   capture_output=True, text=True, timeout=1200
               )
@@ -1034,8 +1040,8 @@ jobs:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
+          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
+            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
             # Strip stale WAL/SHM that mv preserved (it only renames .db).
             # If old data/geohazard.db-wal survives, a subsequent SQLite open
             # would re-apply those frames to the snapshot, re-introducing
@@ -1340,13 +1346,15 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import sqlite3, sys, os, struct
+          import sqlite3, sys, os, struct, subprocess
           def rm_sidefiles(base):
               for ext in ('-wal', '-shm'):
                   p = base + ext
                   if os.path.exists(p):
                       os.unlink(p)
           try:
+              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
+              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -1355,10 +1363,10 @@ jobs:
                   src.close()
                   sys.exit(1)
               # Pre-clean any stale snapshot side-files
-              for p in ('data/geohazard_snapshot.db', 'data/geohazard_snapshot.db-wal', 'data/geohazard_snapshot.db-shm'):
+              for p in ('/mnt/snap/geohazard_snapshot.db', '/mnt/snap/geohazard_snapshot.db-wal', '/mnt/snap/geohazard_snapshot.db-shm'):
                   if os.path.exists(p):
                       os.unlink(p)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
+              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               src.backup(dst)
               # Force DELETE journal_mode on dst BEFORE close so the header
               # WAL flag (inherited from src via backup) is rewritten. Without
@@ -1370,23 +1378,23 @@ jobs:
               dst.execute('VACUUM')
               dst.close()
               src.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
-              verify = sqlite3.connect('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
+              verify = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               verify.execute('PRAGMA journal_mode = DELETE')
               r2 = verify.execute('PRAGMA integrity_check').fetchone()[0]
               verify.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
               if r2 != 'ok':
                   print(f'REFUSING to upload corrupt snapshot (post-backup): {r2[:200]}')
                   sys.exit(1)
               # Defense-in-depth: header.page_count * page_size must equal file size
-              with open('data/geohazard_snapshot.db', 'rb') as f:
+              with open('/mnt/snap/geohazard_snapshot.db', 'rb') as f:
                   hdr = f.read(100)
               ps_raw = struct.unpack('>H', hdr[16:18])[0]
               page_size = 65536 if ps_raw == 1 else ps_raw
               page_count = struct.unpack('>I', hdr[28:32])[0]
               expected = page_count * page_size
-              actual = os.path.getsize('data/geohazard_snapshot.db')
+              actual = os.path.getsize('/mnt/snap/geohazard_snapshot.db')
               if actual != expected:
                   print(f'REFUSING to upload size-mismatched snapshot: header={expected} actual={actual} extra={actual-expected}')
                   sys.exit(1)
@@ -1395,8 +1403,8 @@ jobs:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
+          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
+            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
             # Strip stale WAL/SHM that mv preserved (it only renames .db).
             # If old data/geohazard.db-wal survives, a subsequent SQLite open
             # would re-apply those frames to the snapshot, re-introducing
@@ -1665,13 +1673,15 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import sqlite3, sys, os, struct
+          import sqlite3, sys, os, struct, subprocess
           def rm_sidefiles(base):
               for ext in ('-wal', '-shm'):
                   p = base + ext
                   if os.path.exists(p):
                       os.unlink(p)
           try:
+              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
+              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -1680,10 +1690,10 @@ jobs:
                   src.close()
                   sys.exit(1)
               # Pre-clean any stale snapshot side-files
-              for p in ('data/geohazard_snapshot.db', 'data/geohazard_snapshot.db-wal', 'data/geohazard_snapshot.db-shm'):
+              for p in ('/mnt/snap/geohazard_snapshot.db', '/mnt/snap/geohazard_snapshot.db-wal', '/mnt/snap/geohazard_snapshot.db-shm'):
                   if os.path.exists(p):
                       os.unlink(p)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
+              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               src.backup(dst)
               # Force DELETE journal_mode on dst BEFORE close so the header
               # WAL flag (inherited from src via backup) is rewritten. Without
@@ -1695,23 +1705,23 @@ jobs:
               dst.execute('VACUUM')
               dst.close()
               src.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
-              verify = sqlite3.connect('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
+              verify = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               verify.execute('PRAGMA journal_mode = DELETE')
               r2 = verify.execute('PRAGMA integrity_check').fetchone()[0]
               verify.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
               if r2 != 'ok':
                   print(f'REFUSING to upload corrupt snapshot (post-backup): {r2[:200]}')
                   sys.exit(1)
               # Defense-in-depth: header.page_count * page_size must equal file size
-              with open('data/geohazard_snapshot.db', 'rb') as f:
+              with open('/mnt/snap/geohazard_snapshot.db', 'rb') as f:
                   hdr = f.read(100)
               ps_raw = struct.unpack('>H', hdr[16:18])[0]
               page_size = 65536 if ps_raw == 1 else ps_raw
               page_count = struct.unpack('>I', hdr[28:32])[0]
               expected = page_count * page_size
-              actual = os.path.getsize('data/geohazard_snapshot.db')
+              actual = os.path.getsize('/mnt/snap/geohazard_snapshot.db')
               if actual != expected:
                   print(f'REFUSING to upload size-mismatched snapshot: header={expected} actual={actual} extra={actual-expected}')
                   sys.exit(1)
@@ -1720,8 +1730,8 @@ jobs:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
+          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
+            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
             # Strip stale WAL/SHM that mv preserved (it only renames .db).
             # If old data/geohazard.db-wal survives, a subsequent SQLite open
             # would re-apply those frames to the snapshot, re-introducing
@@ -2314,13 +2324,15 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import sqlite3, sys, os, struct
+          import sqlite3, sys, os, struct, subprocess
           def rm_sidefiles(base):
               for ext in ('-wal', '-shm'):
                   p = base + ext
                   if os.path.exists(p):
                       os.unlink(p)
           try:
+              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
+              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
@@ -2329,10 +2341,10 @@ jobs:
                   src.close()
                   sys.exit(1)
               # Pre-clean any stale snapshot side-files
-              for p in ('data/geohazard_snapshot.db', 'data/geohazard_snapshot.db-wal', 'data/geohazard_snapshot.db-shm'):
+              for p in ('/mnt/snap/geohazard_snapshot.db', '/mnt/snap/geohazard_snapshot.db-wal', '/mnt/snap/geohazard_snapshot.db-shm'):
                   if os.path.exists(p):
                       os.unlink(p)
-              dst = sqlite3.connect('data/geohazard_snapshot.db')
+              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               src.backup(dst)
               # Force DELETE journal_mode on dst BEFORE close so the header
               # WAL flag (inherited from src via backup) is rewritten. Without
@@ -2344,23 +2356,23 @@ jobs:
               dst.execute('VACUUM')
               dst.close()
               src.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
-              verify = sqlite3.connect('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
+              verify = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
               verify.execute('PRAGMA journal_mode = DELETE')
               r2 = verify.execute('PRAGMA integrity_check').fetchone()[0]
               verify.close()
-              rm_sidefiles('data/geohazard_snapshot.db')
+              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
               if r2 != 'ok':
                   print(f'REFUSING to upload corrupt snapshot (post-backup): {r2[:200]}')
                   sys.exit(1)
               # Defense-in-depth: header.page_count * page_size must equal file size
-              with open('data/geohazard_snapshot.db', 'rb') as f:
+              with open('/mnt/snap/geohazard_snapshot.db', 'rb') as f:
                   hdr = f.read(100)
               ps_raw = struct.unpack('>H', hdr[16:18])[0]
               page_size = 65536 if ps_raw == 1 else ps_raw
               page_count = struct.unpack('>I', hdr[28:32])[0]
               expected = page_count * page_size
-              actual = os.path.getsize('data/geohazard_snapshot.db')
+              actual = os.path.getsize('/mnt/snap/geohazard_snapshot.db')
               if actual != expected:
                   print(f'REFUSING to upload size-mismatched snapshot: header={expected} actual={actual} extra={actual-expected}')
                   sys.exit(1)
@@ -2369,8 +2381,8 @@ jobs:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f data/geohazard_snapshot.db ]; then
-            mv data/geohazard_snapshot.db data/geohazard.db
+          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
+            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
             # Strip stale WAL/SHM that mv preserved (it only renames .db).
             # If old data/geohazard.db-wal survives, a subsequent SQLite open
             # would re-apply those frames to the snapshot, re-introducing


### PR DESCRIPTION
## 問題
fetch job (light 等) の `Snapshot DB` step が `Snapshot failed: database or disk is full` で失敗 → merge job が `base missing` で failure → checkpoint 非 upload。merge 最終成功 02:14Z 以降 ~5 run 連続で checkpoint 非前進＝**全テーブルの永続化が停止**（#172 と同系統の disk-full が cloud_fraction 100%完成等で DB 肥大により再発）。

## 真因
各 snapshot step が root fs 上で `src.backup(dst='data/geohazard_snapshot.db')` し ~17GB の2つ目コピーを作る（+VACUUM の temp も /tmp=root fs）。Restore 済 working DB(17GB) と合わせ root fs (~40-65GB) が溢れる。fetch-snet は今回たまたま成功＝marginal で run 毎にブレる。

## 修正（全 6 snapshot step 統一・可逆）
- snapshot dst を `data/geohazard_snapshot.db` → **`/mnt/snap/geohazard_snapshot.db`**（ephemeral scratch ~74GB、merge job が既に /mnt を使用）。root fs peak が 34GB→17GB に。
- 各 snapshot python に `sudo mkdir -p /mnt/snap` + chown（merge job と同パターン）。
- **`SQLITE_TMPDIR=/mnt/snap`** を設定し VACUUM の ~17GB temp も root fs を回避。
- 最終 `mv /mnt/snap/... data/geohazard.db` は cross-fs（coreutils が copy+unlink、old を truncate するので root peak は ~17GB 維持）。
- merge job の snapshot は既に /mnt/merge 上なので対象外。

## 検証観点
次 target=all run で①全 fetch/light の Snapshot DB success（disk-full 解消）②merge success ＝ checkpoint upload で fnet/cloud 等の進捗が永続化。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database snapshot creation and validation processes with improved temporary file handling and error prevention across all fetch jobs
  * Added defense-in-depth header-based validation and multi-layer consistency checks for snapshot integrity
  * Implemented external subprocess-backed verification for cloud fraction data to ensure table-level data accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->