### PR TITLE
fix(backfill): finalise light DB snapshot in place (drop backup+VACUUM)

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2329,72 +2329,48 @@ jobs:
         if: always()
         run: |
           python3 -c "
-          import sqlite3, sys, os, struct, subprocess
+          import sqlite3, sys, os, struct
           def rm_sidefiles(base):
               for ext in ('-wal', '-shm'):
                   p = base + ext
                   if os.path.exists(p):
                       os.unlink(p)
           try:
-              subprocess.run(['sudo', 'mkdir', '-p', '/mnt/snap'], check=True)
-              subprocess.run(['sudo', 'chown', '%d:%d' % (os.getuid(), os.getgid()), '/mnt/snap'], check=True)
-              os.environ['SQLITE_TMPDIR'] = '/mnt/snap'
+              # light owns the full base DB (no overlay extraction), so the
+              # working file IS the artifact. Finalise it in place instead of
+              # src.backup()+VACUUM into /mnt/snap: GitHub ubuntu-latest has no
+              # separate /mnt mount (single root fs), so the old backup made a
+              # 2nd ~24GB copy and VACUUM a 3rd ~24GB temp, overflowing root
+              # once cloud_fraction filled the DB (run 26696792708 light:
+              # 'database or disk is full').
               src = sqlite3.connect('data/geohazard.db')
               src.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+              # journal_mode=DELETE rewrites the header WAL flag so a later open
+              # cannot checkpoint stray frames past header.page_count (root cause
+              # of 2026-05-08 Tree 98196 malformed-image).
+              src.execute('PRAGMA journal_mode = DELETE')
               r = src.execute('PRAGMA integrity_check').fetchone()[0]
-              if r != 'ok':
-                  print(f'REFUSING to snapshot corrupt DB: {r[:200]}')
-                  src.close()
-                  sys.exit(1)
-              # Pre-clean any stale snapshot side-files
-              for p in ('/mnt/snap/geohazard_snapshot.db', '/mnt/snap/geohazard_snapshot.db-wal', '/mnt/snap/geohazard_snapshot.db-shm'):
-                  if os.path.exists(p):
-                      os.unlink(p)
-              dst = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
-              src.backup(dst)
-              # Force DELETE journal_mode on dst BEFORE close so the header
-              # WAL flag (inherited from src via backup) is rewritten. Without
-              # this, verify-side close can checkpoint stray frames into the
-              # main file, extending it past header.page_count and producing
-              # 'database disk image is malformed' on read (root cause of
-              # 2026-05-08 schedule cron Tree 98196 corruption).
-              dst.execute('PRAGMA journal_mode = DELETE')
-              dst.execute('VACUUM')
-              dst.close()
               src.close()
-              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
-              verify = sqlite3.connect('/mnt/snap/geohazard_snapshot.db')
-              verify.execute('PRAGMA journal_mode = DELETE')
-              r2 = verify.execute('PRAGMA integrity_check').fetchone()[0]
-              verify.close()
-              rm_sidefiles('/mnt/snap/geohazard_snapshot.db')
-              if r2 != 'ok':
-                  print(f'REFUSING to upload corrupt snapshot (post-backup): {r2[:200]}')
+              rm_sidefiles('data/geohazard.db')
+              if r != 'ok':
+                  print(f'REFUSING to upload corrupt DB: {r[:200]}')
                   sys.exit(1)
-              # Defense-in-depth: header.page_count * page_size must equal file size
-              with open('/mnt/snap/geohazard_snapshot.db', 'rb') as f:
+              with open('data/geohazard.db', 'rb') as f:
                   hdr = f.read(100)
               ps_raw = struct.unpack('>H', hdr[16:18])[0]
               page_size = 65536 if ps_raw == 1 else ps_raw
               page_count = struct.unpack('>I', hdr[28:32])[0]
               expected = page_count * page_size
-              actual = os.path.getsize('/mnt/snap/geohazard_snapshot.db')
+              actual = os.path.getsize('data/geohazard.db')
               if actual != expected:
-                  print(f'REFUSING to upload size-mismatched snapshot: header={expected} actual={actual} extra={actual-expected}')
+                  print(f'REFUSING to upload size-mismatched DB: header={expected} actual={actual} extra={actual-expected}')
                   sys.exit(1)
-              print(f'Snapshot created (integrity ok, size={actual} matches header pc*ps={expected})')
+              print(f'Snapshot finalised in place (integrity ok, size={actual} matches header pc*ps={expected})')
           except Exception as e:
               print(f'Snapshot failed: {e}')
               sys.exit(1)
           "
-          if [ -f /mnt/snap/geohazard_snapshot.db ]; then
-            mv /mnt/snap/geohazard_snapshot.db data/geohazard.db
-            # Strip stale WAL/SHM that mv preserved (it only renames .db).
-            # If old data/geohazard.db-wal survives, a subsequent SQLite open
-            # would re-apply those frames to the snapshot, re-introducing
-            # the WAL leakage we just guarded against.
-            rm -f data/geohazard.db-wal data/geohazard.db-shm
-          fi
+
 
       - name: Upload light.db artifact
         if: always() && steps.snapshot.outcome == 'success'


### PR DESCRIPTION
Light job repeatedly hit 'Snapshot failed: database or disk is full' (run 26696792708), which left the light artifact missing so the merge job aborted with 'base missing' and no checkpoint was uploaded. As a result fnet/cloud progress stopped being persisted.

## Root cause
GitHub ubuntu-latest has a single root filesystem; there is no separate /mnt mount. df on the light runner showed only /dev/root 145G (no /mnt line). So the /mnt/snap path introduced in #175 (and /mnt/merge in #166) are just directories on root, not a capacity escape hatch.

The light snapshot step copied the full ~24GB working DB via src.backup() into /mnt/snap (a 2nd copy) and then ran VACUUM (a 3rd ~24GB temp via SQLITE_TMPDIR=/mnt/snap), so the snapshot alone needed roughly 72GB on root. Once cloud_fraction reached 100 percent (4.08M rows, ~24GB DB) this exceeded free space and failed. The other 5 fetch jobs only extract a small owned-table overlay, so they were unaffected and passed.

## Fix
Light owns the full base DB (no overlay extraction), so the working file IS the artifact. Finalise it in place instead of backup plus VACUUM:
- wal_checkpoint TRUNCATE, then journal_mode DELETE (keeps the 2026-05-08 Tree-98196 malformed-image guard by rewriting the header WAL flag)
- integrity_check (fail-closed)
- strip -wal/-shm side-files
- header page_count times page_size equals file size check

No second copy and no VACUUM temp. Root peak for the light snapshot drops from ~72GB to ~24GB (1x) and scales as the DB grows.

Only the light job is touched; the 5 fetch-job snapshots are unchanged. YAML validated; src.backup count 6 to 5, VACUUM count 5 to 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database integrity validation and consistency checks during the build process to ensure more reliable release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->