### PR TITLE
fix(backfill): raise GNSS-TEC fetch step timeout 30 to 90 min

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1952,7 +1952,7 @@ jobs:
         id: fetch_gnss_tec
         if: inputs.target == 'all' || inputs.target == 'gnss_tec' || inputs.target == ''
         continue-on-error: true
-        timeout-minutes: 30
+        timeout-minutes: 90
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
           GNSS_TEC_MAX_DATES: ${{ vars.GNSS_TEC_MAX_DATES || '200' }}


### PR DESCRIPTION
## Problem

`gnss_tec` has been stuck at its recent frontier `2025-09-03` even though the missing dates are fetchable. The `Fetch GNSS-TEC` step hard-stops at `timeout-minutes: 30`, which is not enough to clear its backlog: a verified run logged `GNSS-TEC: 398 missing dates (5630 total, 5215 existing, 17 failed-skip)` and the step `timed out after 30 minutes` before draining the queue (12MB/file, MAX_DATES cap 200/run, parallelism 4). So the frontier never advances past the recent publication-lag region.

This is the only true bug among the 3 remaining sub-100% tables (fnet and ioc are progressing correctly via their walks).

## Fix

Raise the `fetch_gnss_tec` step `timeout-minutes` from 30 to 90. Only this step is touched (unique `id: fetch_gnss_tec` anchor) -- the other `timeout-minutes: 30` steps are untouched.

`timeout-minutes` is a cap, not a forced duration: the step still returns as soon as it finishes. The `light` job total budget is 200 min and historically runs ~112 min (with gnss timing out at 30), so worst-case ~172 min with gnss at 90 stays comfortably within budget.

## Verification (pre-merge, RPi5)
- exactly 1 replacement under the `id: fetch_gnss_tec` anchor; `timeout-minutes: 30` count 7 to 6, `timeout-minutes: 90` count 7 to 8
- YAML parses; all 8 jobs present; parsed `fetch_gnss_tec` step `timeout-minutes == 90`
- Recent ~2 months remain genuine Nagoya-ISEE publication lag and self-fill as the source publishes; the 90-min step clears the rest within 1-2 cron cycles (200 dates/run x 8 runs/day).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout duration for data backfill processes to enhance reliability and ensure successful completion of fetching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->