### PR TITLE
fix(backfill): accept restore checkpoint when quick_check times out on 28GB DB

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -261,10 +261,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
@@ -539,10 +551,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
@@ -836,10 +860,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
@@ -1148,10 +1184,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
@@ -1479,10 +1527,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
@@ -1811,10 +1871,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"
@@ -2395,10 +2467,22 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
-              if [ $ic_rc -eq 0 ]; then
+              # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
+              # DB exceeds the quick_check window. The checkpoint was already
+              # integrity-verified when the merge job created it, and the Init DB
+              # step re-checks afterwards, so accept the restored full DB instead
+              # of discarding it for a salvage that also times out. (run
+              # 26817022739: light spent its entire 90min restore budget on two
+              # quick_check+salvage timeouts -> no restore -> 200min job timeout
+              # -> base-missing merge -> stalled chain.)
+              if [ $ic_rc -eq 0 ] || [ $ic_rc -eq 124 ] || [ $ic_rc -eq 137 ] || [ $ic_rc -eq 143 ]; then
                 RESTORED="${ARTIFACT_NAME}"
                 echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-                log "Restored from ${ARTIFACT_NAME}"
+                if [ $ic_rc -eq 0 ]; then
+                  log "Restored from ${ARTIFACT_NAME}"
+                else
+                  log "Restored from ${ARTIFACT_NAME} (quick_check timed out rc=${ic_rc}; verified at creation, accepting)"
+                fi
                 break
               else
                 log "  corrupted (rc=${ic_rc}) -- attempting per-table salvage"


### PR DESCRIPTION
## 問題 (run 26817022739 で再現・実ログ確定)
canonical DB が cloud_fraction 100%化で約28GB に肥大し、Restore step の `check_db_integrity.py --mode=quick` が 1200s(20分)内に終わらず rc=124 (timeout) を返すようになった。既存コードは timeout を corruption と誤判定 → 無駄な salvage(1800s も timeout) → artifact 破棄 → 次 artifact で再 timeout… で restore 90分予算を空費し restore 失敗。

結果、light job (merge の base) が 200分 job timeout で cancel → snapshot fail → light.db 不生成 → merge が base missing で失敗 → checkpoint chain 停滞 (毎 cron 赤)。restore 失敗→fresh Init DB だと空 base で全履歴 zero-out の危険もある。

## 修正
Restore step の integrity 判定で rc=124/137/143 (timeout 系) を corruption でなく採用に変更。全7 restore block (modis/so2/cloud/snet/hinet/light/gnss) に一律適用。

安全性: timeout は corruption でない。checkpoint は (a) merge 作成時に merge_checkpoints.py:_verify で検証済、(b) 直後の Init DB step が full check (rc 124/137/143 は既に keeping DB 許容=確立パターン)、(c) Snapshot step が full integrity_check != ok で fail-closed。本物の corruption (rc=1 等) は従来通り salvage。これで restore は ~30分で完了し light が 200分内に収まる。空 base 危険も解消。

Opus サブエージェントレビュー APPROVE (6観点 YES / 安全性根拠3点を master 実コードで確認 / bash・YAML 妥当 / 7箇所一律)。

## scope 外 (follow-up)
28GB では quick_check が常時 timeout するため整合性 gate は実質 Init/Snapshot 側へ移行。quick_check timeout 値引上げ/検証方式見直しは別途。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database checkpoint restoration workflows to properly handle timeout scenarios in automated data synchronization processes. The system now accepts timeouts as valid outcomes, improving resilience and reducing unnecessary recovery operations across multiple data ingestion sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->