### PR TITLE
fix(backfill): add fetch-hinet to the merge auto-rerun condition

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -3098,6 +3098,7 @@ jobs:
             || needs.fetch-so2.result == 'failure'
             || needs.fetch-cloud.result == 'failure'
             || needs.fetch-snet.result == 'failure'
+            || needs.fetch-hinet.result == 'failure'
             || needs.fetch-gnss.result == 'failure'
             || needs.light.result == 'failure'
           )
@@ -3111,6 +3112,7 @@ jobs:
           echo "  fetch-so2 result:   ${{ needs.fetch-so2.result }}"
           echo "  fetch-cloud result: ${{ needs.fetch-cloud.result }}"
           echo "  fetch-snet result:  ${{ needs.fetch-snet.result }}"
+          echo "  fetch-hinet result: ${{ needs.fetch-hinet.result }}"
           echo "  fetch-gnss result:  ${{ needs.fetch-gnss.result }}"
           echo "  light result:       ${{ needs.light.result }}"
           OUT=$(timeout 30 gh api -X POST \


### PR DESCRIPTION
## 問題 (実ログ確定)
fetch-hinet が「Restore previous database checkpoint」step の最中に runner ごと異常終了 (step ログ未 flush・conclusion 空 = lost-communication/OOM 系の runner 終了、script エラーではない)。間欠的で、早朝 (12:46Z/18:35Z) は success だったが直近2連続 (dispatch 26859610782 + 自然 cron 26860883895) で失敗 → hinet_waveform が停滞。

根本: merge の Auto-rerun failed fetch jobs 条件は modis/so2/cloud/snet/gnss/light を列挙するが fetch-hinet が欠落 (Hi-net=Phase 2(3) で後発追加された際の取り残し)。他 6 job が持つ transient 失敗時の 1-shot 自動 retry を hinet だけ受けられず、間欠 runner 死亡がそのまま停滞になる。

## 修正
fetch-hinet を auto-rerun の if-条件と diagnostic echo ブロックに追加 (needs 順 snet→hinet→gnss)。rerun-failed-jobs は fresh runner で再実行するので runner 固有の transient abort は retry で解消、run_attempt == 1 ガードで無限ループ防止。他 fetch job と完全 parity。YAML parse OK / 既存6 siblings と同型の 2 行追加のみ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic retry mechanism for Hi-net data fetch jobs. Failed Hi-net fetch operations now trigger automatic retry attempts, improving data availability and reducing manual intervention required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->