### PR TITLE
fix(backfill): restore per-job overlay instead of full 28GB checkpoint in fetch jobs

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -196,6 +196,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
@@ -522,6 +523,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
@@ -867,6 +869,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
@@ -1227,6 +1230,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
@@ -1608,6 +1612,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
@@ -1986,6 +1991,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
@@ -2618,6 +2624,7 @@ jobs:
             fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
             fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
             fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            fetch-modis) OWN_PREFIX=""; OWN_TABLES="";;  # full restore: fetch reads cross-table earthquakes master
             *)           OWN_PREFIX="";               OWN_TABLES="";;
           esac
           log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -184,6 +184,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
 
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
@@ -227,7 +242,7 @@ jobs:
             return 1
           }
 
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -261,6 +276,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB
@@ -474,6 +510,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
 
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
@@ -517,7 +568,7 @@ jobs:
             return 1
           }
 
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -551,6 +602,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB
@@ -783,6 +855,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
 
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
@@ -826,7 +913,7 @@ jobs:
             return 1
           }
 
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -860,6 +947,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB
@@ -1107,6 +1215,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
 
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
@@ -1150,7 +1273,7 @@ jobs:
             return 1
           }
 
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -1184,6 +1307,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB
@@ -1452,6 +1596,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
           # in job logs without polluting the parsed run_id list.
@@ -1493,7 +1652,7 @@ jobs:
             rm -f "$stderr_file"
             return 1
           }
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -1527,6 +1686,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB
@@ -1794,6 +1974,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
 
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
@@ -1837,7 +2032,7 @@ jobs:
             return 1
           }
 
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -1871,6 +2066,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB
@@ -2390,6 +2606,21 @@ jobs:
           mkdir -p data results
           RESTORED=""
           MAX_TRIES=5
+          # Per-job owned-table overlay. Each fetch job uploads a small
+          # backfill-<job>- overlay (its owned table(s) only); preferring that over
+          # the full ~28GB backfill-checkpoint- avoids expanding a 17GB artifact on a
+          # disk/RAM-constrained ubuntu-latest runner -- the runner abort that was
+          # stalling fetch-hinet mid-restore. modis (needs the cross-table earthquakes
+          # master) and light (base builder) keep full-checkpoint restore via default.
+          case "${{ github.job }}" in
+            fetch-hinet) OWN_PREFIX="backfill-hinet-"; OWN_TABLES="hinet_waveform";;
+            fetch-gnss)  OWN_PREFIX="backfill-gnss-";  OWN_TABLES="gnss_tec";;
+            fetch-so2)   OWN_PREFIX="backfill-so2-";   OWN_TABLES="so2_column";;
+            fetch-cloud) OWN_PREFIX="backfill-cloud-"; OWN_TABLES="cloud_fraction";;
+            fetch-snet)  OWN_PREFIX="backfill-snet-";  OWN_TABLES="snet_waveform fnet_waveform";;
+            *)           OWN_PREFIX="";               OWN_TABLES="";;
+          esac
+          log "own-overlay prefix: ${OWN_PREFIX:-<none; full-checkpoint restore>}"
 
           # Fetch artifact list with up to 3 attempts and exponential backoff
           # between attempts (1s, 3s). stderr goes to a temp file so it shows up
@@ -2433,7 +2664,7 @@ jobs:
             return 1
           }
 
-          for PREFIX in "backfill-checkpoint-" "database-checkpoint-"; do
+          for PREFIX in ${OWN_PREFIX:+"$OWN_PREFIX"} "backfill-checkpoint-" "database-checkpoint-"; do
             [ -n "$RESTORED" ] && break
             log "scanning prefix=${PREFIX}"
             RUN_IDS=$(fetch_artifact_list "$PREFIX")
@@ -2467,6 +2698,27 @@ jobs:
               log "  copied (${DB_SIZE}) -- checking integrity"
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db --mode=quick
               ic_rc=$?
+              # --- Own-overlay fast path (per-table overlay restore) ---
+              # Strict: accept only a clean (rc=0) own-overlay whose owned table(s) hold
+              # rows; otherwise discard and fall through to the full checkpoint (which is
+              # reproducible and always carries every table).
+              if [ -n "$OWN_PREFIX" ] && [ "$PREFIX" = "$OWN_PREFIX" ]; then
+                if [ $ic_rc -ne 0 ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} quick_check rc=${ic_rc} -- discard, try next/full"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                OVL_ROWS=$(timeout 120 python3 -c "import sqlite3; c=sqlite3.connect('data/geohazard.db'); print(sum(c.execute('SELECT COUNT(*) FROM '+t).fetchone()[0] for t in '''${OWN_TABLES}'''.split()))" 2>/dev/null)
+                if [ -z "$OVL_ROWS" ] || [ "$OVL_ROWS" = "0" ]; then
+                  log "  own-overlay ${ARTIFACT_NAME} empty/unreadable for (${OWN_TABLES}) -- discard, try full checkpoint"
+                  rm -f data/geohazard.db data/geohazard.db-wal data/geohazard.db-shm
+                  continue
+                fi
+                RESTORED="${ARTIFACT_NAME}"
+                echo "restored=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
+                log "Restored from own-overlay ${ARTIFACT_NAME} (${OWN_TABLES} total=${OVL_ROWS} rows)"
+                break
+              fi
               # A quick_check TIMEOUT (124/137/143) is NOT corruption: the ~28GB
               # DB exceeds the quick_check window. The checkpoint was already
               # integrity-verified when the merge job created it, and the Init DB


### PR DESCRIPTION
## 問題（実ログ確定）
6個の分離 fetch job (modis/so2/cloud/snet/hinet/gnss) の Restore step は、自テーブルのインクリメンタル fetch をするだけなのに毎回 full `backfill-checkpoint-`(~28GB, 17GB圧縮) を DL・/tmp 展開・copy していた。一方 upload は `extract_overlay.py` で抽出した小さな `backfill-<job>-` overlay（自テーブルのみ）だけ。この非対称が、disk/RAM 制約の ubuntu-latest runner で restore 中の runner abort（lost-communication, job log が BlobNotFound）を招き、fetch-hinet が2連続死亡 (runs 26859610782 / 26860883895) して coverage 停滞した。DB 肥大とともにリスク増。#188 の auto-rerun は死亡を retry するだけで負荷は減らない。

## 修正
各 fetch job の restore で、まず自分の小さな overlay (`backfill-<job>-`) を優先して復元（overlay は自テーブルの累積全行を保持）。無い時（初回 / 7日 retention 切れ / chain 断絶）のみ full `backfill-checkpoint-` / `database-checkpoint-` に fallback。
- **strict accept**: clean rc=0 quick_check **かつ** owned table 非空。NG なら discard して full へ fall through。
- **modis は full restore 維持**: `fetch_modis_lst.py` が cross-table の `earthquakes` master を読んで fetch 対象日を決めるため（modis_lst-only overlay には earthquakes が無い）。
- **light は base builder** なので対象外。
- 選択は `${{ github.job }}` の case で行い、全7 restore block を均一に保つ（modis/light は空 default で従来動作）。

## 検証
- Opus サブエージェントで6 fetcher の read/write テーブル・cross-table依存を精査し modis の earthquakes 依存を検出 → modis 除外を反映。
- 変換は3アンカー replace-all（各7回）、yaml.safe_load 妥当性確認済み。
- 残りの検証は CI（backfill schedule run）で各 fetch job が own-overlay restore に成功し runner abort が消えること。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the database restoration process in build workflows with enhanced integrity validation and improved artifact selection logic. The system now intelligently handles restoration attempts with better error recovery, ensuring more reliable and efficient build pipeline execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yasumorishima/japan-geohazard-monitor/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->