### PR TITLE
fix(ml): drop dead LIS/OTD lightning feature from forward prediction

### DIFF
--- a/scripts/ml_prediction.py
+++ b/scripts/ml_prediction.py
@@ -2672,7 +2672,7 @@ async def run_ml_prediction():
 
     # --- Phase 20: Monthly lightning climatology ---
     logger.info("--- Loading Phase 20 data (LIS/OTD flash rate, WWLLN thunder hour) ---")
-    lightning_lis_otd_data = await load_phase20_lightning_lis_otd(DB_PATH)
+    lightning_lis_otd_data = None  # LIS/OTD satellite ended 2014 -> always 0 for forward (>=2015) dates (temporal confound); live lightning is covered by WWLLN (lightning_thunder_hour). Pass None so get_active_feature_names() excludes the group from train and predict. Raw table retained as backtest/research asset.
     lightning_thunder_hour_data = await load_phase20_lightning_thunder_hour(DB_PATH)
 
     # Multi-target loop

--- a/scripts/ml_prediction.py
+++ b/scripts/ml_prediction.py
@@ -2671,7 +2671,7 @@ async def run_ml_prediction():
     snet_waveform_data, snet_velocity_data, snet_highgain_data = await load_phase18_snet_waveform(DB_PATH)
 
     # --- Phase 20: Monthly lightning climatology ---
-    logger.info("--- Loading Phase 20 data (LIS/OTD flash rate, WWLLN thunder hour) ---")
+    logger.info("--- Loading Phase 20 data (WWLLN thunder hour; LIS/OTD excluded from forward features) ---")
     lightning_lis_otd_data = None  # LIS/OTD satellite ended 2014 -> always 0 for forward (>=2015) dates (temporal confound); live lightning is covered by WWLLN (lightning_thunder_hour). Pass None so get_active_feature_names() excludes the group from train and predict. Raw table retained as backtest/research asset.
     lightning_thunder_hour_data = await load_phase20_lightning_thunder_hour(DB_PATH)
 


### PR DESCRIPTION
## Problem

LIS/OTD satellite lightning ended **2014**. The three `lis_otd_flash_rate*` features (Phase 20) are looked up by the prediction date's actual year-month:

- `src/features.py:1136` — `month_str = date_str[:7] + "-01"` (the prediction month), key `(month_str, cell_lat, cell_lon)`
- `scripts/ml_prediction.py:1337` `load_phase20_lightning_lis_otd` builds the dict **only from the `lightning_lis_otd` table (1995–2014)**

So for any forward (>=2015) prediction date the key never matches → all three features are **always 0.0**. The dynamic safeguard `get_active_feature_names()` does **not** drop them, because the loader returns a non-empty (historical) dict. Within training that spans 2011–present, the feature is nonzero only in 2011–2014 rows → a **temporal confound**, not a precursor signal.

Live lightning is already captured separately by **WWLLN** (`lightning_thunder_hour`, loaded on the adjacent line, active to present).

## Change

`scripts/ml_prediction.py:2675` — pass `None` for `lightning_lis_otd_data` so `get_active_feature_names()` excludes the `lightning_lis_otd` group from **both training and inference**. Log line aligned.

## Why this is safe

- The model is **not** a fixed-width artifact: `build_dataset` computes `feature_mask`/`active_feature_names` each run and trains + predicts on the same active set. Group exclusion is a first-class, already-exercised path.
- Excluding the group drops 3 columns consistently from train and predict → no shape mismatch.
- No forward signal lost (WWLLN covers live lightning).
- Fully reversible (single assignment). The `lightning_lis_otd` table/fetcher and `load_phase20_lightning_lis_otd` are **retained** as a backtest/research asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model configuration to exclude deprecated satellite lightning data from inputs, ensuring only current and active data sources are used for predictions. Added documentation clarifying which data sources are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->