### PR TITLE
fix(so2): repoint OMI SO2 fetcher from frozen OMSO2G.003 to live V004

### DIFF
--- a/.github/workflows/test-earthdata-auth.yml
+++ b/.github/workflows/test-earthdata-auth.yml
@@ -54,8 +54,8 @@ jobs:
                   # Step 1: Raw fetch to see actual data format
                   url = (
                       'https://acdisc.gesdisc.eosdis.nasa.gov/opendap/HDF-EOS5/'
-                      'Aura_OMI_Level2G/OMSO2G.003/2024/'
-                      'OMI-Aura_L2G-OMSO2G_2024m0101_v003-2024m0103t164059.he5.ascii'
+                      'Aura_OMI_Level2G/OMSO2G.004/2024/'
+                      'OMI-Aura_L2G-OMSO2G_2024m0101_v004-2025m0904t091514.he5.ascii'
                       '?ColumnAmountSO2_PBL[0:0][455:543][1207:1319]'
                   )
                   status, text = await earthdata_fetch(session, url, timeout=aiohttp.ClientTimeout(total=60))
@@ -136,8 +136,8 @@ jobs:
               session = await get_earthdata_session()
               url = (
                   'https://acdisc.gesdisc.eosdis.nasa.gov/opendap/HDF-EOS5/'
-                  'Aura_OMI_Level2G/OMSO2G.003/2024/'
-                  'OMI-Aura_L2G-OMSO2G_2024m0101_v003-2024m0103t164059.he5.ascii'
+                  'Aura_OMI_Level2G/OMSO2G.004/2024/'
+                  'OMI-Aura_L2G-OMSO2G_2024m0101_v004-2025m0904t091514.he5.ascii'
                   '?ColumnAmountSO2_PBL[0:0][500:500][1250:1250]'
               )
               try:

--- a/scripts/fetch_omi_so2.py
+++ b/scripts/fetch_omi_so2.py
@@ -50,8 +50,10 @@ logger = logging.getLogger(__name__)
 
 # GES DISC OPeNDAP for OMSO2G (OMI Level 2G daily gridded, 0.25° grid)
 # OMSO2e was removed from GES DISC; OMSO2G is the replacement (2004-present)
+# V003 archive froze ~2025-06; V004 is the live continuation to present
+# (identical 0.25-deg 720x1440 grid + ColumnAmountSO2 variable, verified via OPeNDAP .dds)
 # Note: GES DISC requires URS redirect + Basic Auth (Bearer returns 401)
-GESDISC_OPENDAP = "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/HDF-EOS5/Aura_OMI_Level2G/OMSO2G.003"
+GESDISC_OPENDAP = "https://acdisc.gesdisc.eosdis.nasa.gov/opendap/HDF-EOS5/Aura_OMI_Level2G/OMSO2G.004"
 
 # Japan bbox in grid indices (0.25° resolution)
 # Lat: -89.875 to 89.875 (720 cells), Lon: -179.875 to 179.875 (1440 cells)
@@ -122,7 +124,7 @@ async def _resolve_so2_filename(session: aiohttp.ClientSession, year: int, date_
     """Resolve OMSO2G filename from OPeNDAP contents listing.
 
     OMSO2G files are stored directly under year/ (no DOY subdirectory).
-    Filename: OMI-Aura_L2G-OMSO2G_{YYYY}m{MMDD}_v003-{revision}.he5
+    Filename: OMI-Aura_L2G-OMSO2G_{YYYY}m{MMDD}_v004-{revision}.he5
     """
 
     mmdd = date_str[5:7] + date_str[8:10]  # "2024-01-15" -> "0115"
@@ -397,7 +399,7 @@ async def main():
         logger.info(
             "SO2 fetch complete: 0 records from %d dates. "
             "Likely cause: no OMI OMSO2G archive files exist for these dates "
-            "(OMI data physically ends ~2025-06-08 due to instrument coverage degradation). "
+            "(if persistent, check Earthdata auth or the OMSO2G.004 listing for these dates). "
             "If auth failed, 'HTTP 4' errors appear in WARNING logs above.",
             len(dates_to_fetch),
         )

--- a/scripts/fetch_omi_so2.py
+++ b/scripts/fetch_omi_so2.py
@@ -400,7 +400,7 @@ async def main():
             "SO2 fetch complete: 0 records from %d dates. "
             "Likely cause: no OMI OMSO2G archive files exist for these dates "
             "(if persistent, check Earthdata auth or the OMSO2G.004 listing for these dates). "
-            "If auth failed, 'HTTP 4' errors appear in WARNING logs above.",
+            "If auth failed, 'auth failed (HTTP 401/403)' entries appear in the INFO logs above.",
             len(dates_to_fetch),
         )
     else:


### PR DESCRIPTION
## Problem

The so2_column MAX date is stuck at **2025-06-08**, so so2_column_anomaly is silently ~0 for any current (>=2025-07) prediction. The old diagnostic in scripts/fetch_omi_so2.py blamed an instrument end.

## Root cause (verified, not a dead source)

The fetcher is pinned to the **frozen V003** archive (.../Aura_OMI_Level2G/OMSO2G.003, fetch_omi_so2.py:54). NASA confirms OMI SO2 **continues to present** (Aura operates through mid-2026, only minor drift), published as **OMSO2G.004**.

Verified directly via OPeNDAP on the V004 archive:
- **2026 data exists**: OMI-Aura_L2G-OMSO2G_2026m0101_v004-2026m0102t205359.he5 (near-real-time, produced next day).
- **Identical grid/variable**: the .dds shows ColumnAmountSO2[nCandidate=15][YDim=720][XDim=1440], i.e. the same **0.25 deg 720x1440** grid and same variable name as V003. (The catalog 0.125 deg text is inaccurate for this product.)

So the existing Japan-bbox index math (LAT 455-543 / LON 1207-1319, x0.25, nCandidate [0:0]) and ASCII parser carry over unchanged. The filename resolver matches by **date prefix** (version-agnostic), so the only required change is the dataset-version segment of the URL.

## Change
scripts/fetch_omi_so2.py: OMSO2G.003 -> OMSO2G.004, plus a corrected (now-false) instrument-end comment, a version note, and the docstring. The single behavioural change is the URL. No parse/grid changes.

## Effect and caveat
The next backfill run fills 2025-06 -> present (recent-first is already the fetcher priority), reviving so2_column_anomaly as a fresh forward feature. **Caveat**: historical rows stay V003, so a V003/V004 boundary at 2025-06 exists. The anomaly uses a local rolling baseline, so the boundary impact is minor. A full V004 re-fetch can follow as a separate step if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to use the latest version of the NASA GES DISC SO2 data archive.
  * Refined error messages to provide clearer guidance for troubleshooting data retrieval issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->