### PR TITLE
fix(ml): drop dead daily 'lightning' feature from forward prediction

### DIFF
--- a/scripts/ml_prediction.py
+++ b/scripts/ml_prediction.py
@@ -2636,7 +2636,7 @@ async def run_ml_prediction():
     # --- Phase 9: Load non-traditional precursor data ---
     logger.info("--- Loading Phase 9 data (cosmic ray, lightning, geomag, animal) ---")
     cosmic_ray_data = await load_phase9_cosmic_ray(DB_PATH)
-    lightning_data = await load_phase9_lightning(DB_PATH)
+    lightning_data = None  # Daily 'lightning' group is fed only by iss_lis_lightning (ISS LIS, ended 2023-11) -- the Blitzortung 'lightning' table is a permanent 0-row deprecated no-op, so lightning_count_7d/anomaly are always 0 for forward (>=2024) dates (temporal confound). No live daily-lightning source exists (WWLLN feeds the separate monthly lightning_thunder_hour group). Excluded from forward features via get_active_feature_names. iss_lis data retained as a backtest asset.
     geomag_spectral_data = await load_phase9_geomag_spectral(DB_PATH)
     animal_data = await load_phase9_animal(DB_PATH)
 


### PR DESCRIPTION
## Problem

The daily `lightning` feature group (`lightning_count_7d`, `lightning_anomaly`) is silently ~0 for any current (2024+) prediction.

## Root cause (verified in code)

`load_phase9_lightning` (`scripts/ml_prediction.py:1289`) merges two tables:
- `lightning` (Blitzortung) — `fetch_blitzortung.py` is a **deprecated no-op stub**. Its own docstring states the table has been at **0 rows since the start of the project** (Blitzortung historical archive is access-restricted, live API exposes only ~2h, no Japan-capable free source).
- `iss_lis_lightning` (NASA ISS LIS) — ended **2023-11** (the satellite instrument stopped).

So the group's data is **iss_lis only (2017-03 -> 2023-11)**. Because that history is non-empty, `get_active_feature_names()` does NOT exclude the group, yet for any forward date the lookup finds nothing, so the features are **always 0** — a temporal confound (nonzero only in 2017-2023 training rows). There is no live daily-lightning source. WWLLN lightning is captured separately by the monthly `lightning_thunder_hour` group.

## Change

`scripts/ml_prediction.py`: pass `None` for `lightning_data` at the load site so `get_active_feature_names()` excludes the group from **both training and inference**.

## Why safe

Same mechanism and class as the merged LIS/OTD fix (#190). The model builds `feature_mask`/`active_feature_names` per run, so dropping the group is shape-consistent across train and predict. No live signal is lost. The `lightning` / `iss_lis_lightning` tables and `load_phase9_lightning` are retained as backtest assets. Fully reversible (single assignment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified ML pipeline configuration: Daily lightning data for Phase 9 predictions is now excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->