### PR TITLE
feat(analysis): skip_fetch — retrain ML on latest backfill-checkpoint (complete DB)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,11 +18,17 @@ on:
         required: false
         default: 'all'
 
+      skip_fetch:
+        description: 'Skip the fetch job and restore the latest complete backfill-checkpoint DB directly (true/false)'
+        required: false
+        default: 'false'
+
 jobs:
   # ====== JOB 1: FETCH ======
   # Data collection + validation + gap diagnosis.
   # Runs independently with its own 6-hour budget.
   fetch:
+    if: ${{ github.event.inputs.skip_fetch != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 330  # Must be < GitHub's 360min hard limit so if: always() steps can save DB
 
@@ -877,14 +883,46 @@ jobs:
           pip install aiohttp aiosqlite scikit-learn scipy numpy netCDF4
 
       - name: Restore database from fetch job
+        if: ${{ github.event.inputs.skip_fetch != 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: database-checkpoint-${{ github.run_id }}
           path: .
 
+      - name: Restore database from latest backfill checkpoint (skip_fetch)
+        if: ${{ github.event.inputs.skip_fetch == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash {0}
+        run: |
+          set +e
+          mkdir -p data
+          BF_RUN=$(gh api "repos/${{ github.repository }}/actions/artifacts?per_page=100"             --jq '[.artifacts[] | select(.name | startswith("backfill-checkpoint-")) | select(.expired == false)] | sort_by(.created_at) | reverse | .[0].workflow_run.id // empty')
+          if [ -z "$BF_RUN" ]; then
+            echo "::error::No backfill-checkpoint artifact found -- cannot restore complete DB"
+            exit 1
+          fi
+          echo "Restoring backfill-checkpoint-$BF_RUN ..."
+          rm -rf /tmp/bf-restore
+          gh run download "$BF_RUN" --repo ${{ github.repository }} --name "backfill-checkpoint-$BF_RUN" --dir /tmp/bf-restore
+          if [ $? -ne 0 ]; then
+            echo "::error::Download of backfill-checkpoint-$BF_RUN failed"
+            exit 1
+          fi
+          DB_FILE="/tmp/bf-restore/geohazard.db"
+          [ ! -f "$DB_FILE" ] && DB_FILE="/tmp/bf-restore/data/geohazard.db"
+          if [ ! -f "$DB_FILE" ]; then
+            echo "::error::No geohazard.db inside backfill-checkpoint-$BF_RUN"
+            exit 1
+          fi
+          mv "$DB_FILE" data/geohazard.db
+          rm -f data/geohazard.db-wal data/geohazard.db-shm
+          echo "Restored backfill DB ($(du -h data/geohazard.db | cut -f1)) from run $BF_RUN"
+
       # Needed by the final Discord notification step to read
       # results/midrun/snapshot.log and surface snapshot step status.
       - name: Restore midrun report from fetch job
+        if: ${{ github.event.inputs.skip_fetch != 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: midrun-fetch-${{ github.run_id }}


### PR DESCRIPTION
## Problem
`analysis.yml` (ML retrain) restores its training DB from its own `database-checkpoint-` lineage, whose latest non-expired artifact is from **2026-03-30 (252 MB)**. Meanwhile `backfill.yml` maintains the **complete DB** as `backfill-checkpoint-` (latest 2026-06-05, **5.8 GB**, all tables to present incl. so2/ioc forward fixes). The two pipelines are disconnected, so weeks of data-completeness work never reach the model -- retrains run on a 2-month-old base + a redundant ~5 h re-fetch.

## Change (additive, non-breaking)
Add a `skip_fetch` workflow_dispatch input (default `'false'`).
- `skip_fetch=='true'`: the `fetch` job is skipped entirely; `analyze` restores the **latest `backfill-checkpoint-`** (complete DB) cross-run and runs ML directly. Fast (skips ~5 h fetch) **and** correct (complete data).
- default (`'false'`): **behaviour unchanged** -- fetch runs, analyze uses the same-run `database-checkpoint-${{ github.run_id }}`.

## Notes
- `backfill-checkpoint-` is a raw single `geohazard.db` (upload-artifact zips internally, download transparently unzips); restore mirrors backfill.yml's own logic (root `geohazard.db` then `data/` fallback, WAL/SHM purge). `mv` (not `cp`) to keep disk peak low on the analyze runner.
- GHA skipped-needs: `analyze` (`needs: fetch`, `if: always() && needs.fetch.result != 'cancelled'`) runs when fetch is `skipped`. No `if:` change needed.
- Artifact-missing => fail-fast (no ML on empty DB). backfill.yml untouched. CSES step kept (its active path is live INTERMAGNET hourly).

Single-file change to `.github/workflows/analysis.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow to support conditional execution and flexible database restoration strategies, enabling faster and more efficient CI/CD operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->