### PR TITLE
fix(ml): import safe_connect in ml_prediction.py (NameError regression since 2cdb43a1)

### DIFF
--- a/scripts/csep_benchmark.py
+++ b/scripts/csep_benchmark.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from db_connect import safe_connect
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)

--- a/scripts/ml_prediction.py
+++ b/scripts/ml_prediction.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import aiosqlite
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+from db_connect import safe_connect
 from config import DB_PATH
 from features import (
     FEATURE_NAMES,


### PR DESCRIPTION
## Root cause

Commit 2cdb43a1 (2026-03-24, "prevent DB corruption with SYNCHRONOUS=FULL") replaced every aiosqlite.connect() with safe_connect() across scripts/ml_prediction.py (30+ call sites) but never added the `from db_connect import safe_connect` import that every other analysis/fetch script received.

At runtime the first DB access in load_events() (line 84) raises:

    NameError: name 'safe_connect' is not defined

so ml_prediction.py crashes at startup. The analysis workflow runs it with a non-fatal fallback echo, so the crash is swallowed, the AUC-extraction step prints "No ML results", and the run stays green. The ML + stacking AUC pipeline has produced nothing for ~2.5 months.

Discovered while verifying retrain run 27005327429 (first run on the complete 5.8GB backfill DB via the new skip_fetch path from #194): skip_fetch / restore / all 30 analysis steps worked, but ml_prediction.py crashed with the NameError.

## Fix

Add the one missing import next to the other first-party imports. db_connect.py only imports os/contextlib/aiosqlite (no src deps), and scripts/ is on sys.path, so the import resolves exactly as it does in the ~20 sibling scripts.

## Verification

- compile() passes on the patched file.
- Every sibling analysis script (pattern_informatics, coulomb, cluster, etas, gnss_tec, ...) already uses this exact import and ran successfully in run 27005327429 (steps 9-20 green).
- After merge: re-run analysis with skip_fetch=true and confirm a real Test AUC is emitted (compare to prior best 0.7540, Phase 15g).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a database connectivity issue that was preventing the ML prediction module from functioning correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Update: same bug also in csep_benchmark.py (fixed in this PR)

A full sweep of all 86 scripts/*.py found a **second** instance of the identical regression: `scripts/csep_benchmark.py` calls `async with safe_connect()` (load(), line 549) without importing it, crashing the CSEP step the same way (also masked by a non-fatal fallback echo). Added the same one-line import. After both fixes the sweep reports zero remaining `uses safe_connect / no import` mismatches across the repo.

Files changed: `scripts/ml_prediction.py`, `scripts/csep_benchmark.py` (one import line each).
