### PR TITLE
fix(ml): read correct AUC keys in ML-complete notify/report

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1077,10 +1077,11 @@ jobs:
               print('No ML results')
           else:
               d = json.loads(open(files[-1]).read())
-              cv = d.get('cv_auc_pooled', '?')
-              test = d.get('test_auc', {}).get('rf', '?')
-              features = d.get('n_features_active', '?')
-              print(f'CV={cv} Test={test} feat={features}')
+              t = d.get('targets', {}).get('M5+', {})
+              cv = t.get('walk_forward_cv', {}).get('aggregate', {}).get('pooled_auc', '?')
+              test = t.get('final_model', {}).get('performance', {}).get('auc_roc_test', '?')
+              features = d.get('metadata', {}).get('n_features', '?')
+              print(f'M5+ CV={cv} Test={test} feat={features}')
           " 2>/dev/null || echo "AUC: unavailable")
           # Save to log file for artifact retrieval
           echo "=== ML Phase Complete ===" > results/midrun/ml_report.txt


### PR DESCRIPTION
## Problem

The "Notify Discord — ML complete" step extracts AUC with a `python3 -c` snippet that reads stale top-level keys (`cv_auc_pooled`, `test_auc.rf`, `n_features_active`). ml_prediction.py's output JSON nests these under per-target blocks, so the snippet always fell back to `?` and the Discord embed + `ml_report.txt` showed `CV=? Test=? feat=?` even when ML succeeded.

Surfaced right after #195 fixed the NameError: run 27043801663 produced a real result JSON but the report still said `CV=? Test=? feat=?`.

## Fix

Read the real nested paths for the primary M5+ target:
- `targets.M5+.walk_forward_cv.aggregate.pooled_auc`
- `targets.M5+.final_model.performance.auc_roc_test`
- `metadata.n_features`

## Verification

Confirmed against run 27043801663's `ml_prediction_20260605_232016.json`: M5+ CV pooled **0.7418**, Test **0.7499**, **85** features (≈ prior best 0.7540). YAML validated with `yaml.safe_load`. Cosmetic/reporting only — no model or data-path change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated metrics extraction logic for ML result notifications to align with revised data schema format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->