### PR TITLE
fix(backfill): alert instead of silently rebuilding the base DB from empty

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2134,6 +2134,20 @@ jobs:
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
 
+      # 2026-07-24 incident: the backfill-checkpoint artifact chain expired
+      # (retention cut 30 -> 3 days while every scheduled run was cancelled
+      # in the queue for 9 days) and this job silently rebuilt the base DB
+      # from empty -- tec / nightlight / iss_lis_lightning were lost and the
+      # HF row-count guard has been refusing to publish ever since. Fail loudly
+      # instead: reseed the chain from Hugging Face, then let the cron resume.
+      - name: Guard against rebuilding the base DB from empty
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to rebuild the base DB from empty on a scheduled run. Run reseed-checkpoint-from-hf.yml to restore the chain from the Hugging Face canonical copy, then let the schedule resume."
+          exit 1
+
       - name: Init DB if missing or corrupt
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
@@ -3045,6 +3059,7 @@ jobs:
           "
 
       - name: Upload canonical DB to Hugging Face (durable primary storage)
+        id: hf_upload
         # Replaces the retired RPi5 SSD mirror. The Hugging Face dataset
         # yasumorishima/japan-geohazard is now the canonical durable copy.
         # Gated to ONE cron tick per day (UTC 00:00) -- not every 3h run --
@@ -3070,7 +3085,9 @@ jobs:
             --squash
 
       - name: Coverage report
-        if: steps.snapshot.outcome == 'success'
+        if: >-
+          (success() || failure())
+          && steps.snapshot.outcome == 'success'
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
         run: |
@@ -3120,7 +3137,8 @@ jobs:
         # checkpoint. `schedule` always runs on the default branch so this
         # does not block the production pipeline.
         if: >-
-          steps.snapshot.outcome == 'success'
+          (success() || failure())
+          && steps.snapshot.outcome == 'success'
           && github.ref == 'refs/heads/master'
           && (github.event_name != 'workflow_dispatch'
               || inputs.target == 'all'
@@ -3404,7 +3422,7 @@ jobs:
       - name: Create issue on failure
         if: >-
           always()
-          && !(github.event_name == 'schedule' && github.run_attempt == 1)
+          && (steps.hf_upload.outcome == 'failure' || needs.light.outputs.restore_restored == 'none' || !(github.event_name == 'schedule' && github.run_attempt == 1))
           && (
             needs.light.outputs.fetch_earthquakes == 'failure' ||
             needs.light.outputs.fetch_tec_event == 'failure' ||
@@ -3438,7 +3456,9 @@ jobs:
             needs.light.outputs.fetch_dart == 'failure' ||
             needs.light.outputs.fetch_ioc_sealevel == 'failure' ||
             needs.light.outputs.fetch_ioc_dart == 'failure' ||
-            steps.merge.outcome == 'failure'
+            steps.merge.outcome == 'failure' ||
+            steps.hf_upload.outcome == 'failure' ||
+            needs.light.outputs.restore_restored == 'none'
           )
         env:
           GH_TOKEN: ${{ github.token }}
@@ -3477,6 +3497,8 @@ jobs:
           [ "${{ needs.light.outputs.fetch_ioc_sealevel }}" = "failure" ] && FAILED="$FAILED ioc_sealevel"
           [ "${{ needs.light.outputs.fetch_ioc_dart }}" = "failure" ] && FAILED="$FAILED ioc_dart"
           [ "${{ steps.merge.outcome }}" = "failure" ] && FAILED="$FAILED merge"
+          [ "${{ steps.hf_upload.outcome }}" = "failure" ] && FAILED="$FAILED hf_upload"
+          [ "${{ needs.light.outputs.restore_restored }}" = "none" ] && FAILED="$FAILED checkpoint_chain_lost"
           FAILED=$(echo "$FAILED" | xargs)
 
           if [ -f data/geohazard.db ]; then


### PR DESCRIPTION
## Incident

On 2026-07-24 the `backfill-checkpoint-*` artifact chain expired and the `light`
job rebuilt the canonical DB **from an empty file**, silently. Primary evidence,
run 30078904889 (the first success after a 9-day drought):

```
[09:49:19] trying artifact: backfill-checkpoint-30062784844
[09:52:46]   download failed (rc=1) -- skip
   ... all 5 backfill-checkpoint- + 3 database-checkpoint- candidates failed ...
[10:07:58] No usable checkpoint found -- will init fresh DB
2026-07-24 10:08:00 [INFO] Database initialized: ./data/geohazard.db
```

Two causes had to coincide:

1. `e759fe5` (2026-07-15) cut checkpoint retention 30 -> 3 days.
2. Every scheduled run between 2026-07-15 08:08 and 2026-07-24 08:26 was
   cancelled while queued (runs take longer than the 3h cron interval), so no
   new checkpoint was produced for 9 days and the 3-day chain expired.

State of the rebuilt DB vs the Hugging Face canonical copy (coverage report of
run 30363600697):

| table | rebuilt chain | HF canonical |
|---|---|---|
| `tec` | 0 rows | 6,440,742 |
| `iss_lis_lightning` | table missing | 952 |
| `nightlight` | table missing | 929 |
| `ioc_sea_level` | 120,280,581 | 176,345,275 |
| `dart_pressure` | 394,999 | 973,419 |

The `hf_sync.py` row-count guard has correctly refused to publish since
(`refusing to upload -- row-count regression in 9 table(s)`), so the canonical
copy on Hugging Face is intact. **No data was lost.**

## Why nobody was told

`Create issue on failure` is wired to the fetch-step outputs and
`steps.merge.outcome` only. The Hugging Face upload is a *later* step in the
same job, so a guard trip failed the run without matching any clause -- the
2026-07-25 and 2026-07-27 failures produced no issue at all. The last
auto-filed issue is from 2026-06-03.

## Changes

- **`light`: new `Guard against rebuilding the base DB from empty`.** When the
  restore step reports `restored=none` on a scheduled run, fail instead of
  initialising an empty DB. Manual dispatch is unaffected, so bootstrap and
  recovery runs still work.
- **`id: hf_upload` on the Hugging Face upload step** so its outcome can be
  referenced.
- **`Create issue on failure` now fires on `steps.hf_upload.outcome == 'failure'`
  and on `needs.light.outputs.restore_restored == 'none'`.** Both bypass the
  attempt-1 suppression: an auto-rerun cannot un-expire artifacts, and the HF
  guard does not re-trip differently on a second attempt.
- **`Coverage report` and `Upload checkpoint artifact` now run under
  `(success() || failure())`.** Previously a failed HF upload skipped them, so a
  guard trip also cost that run its checkpoint -- exactly the starvation that
  caused this incident.

`restore_restored` was already exported by the `light` job and unused; this PR
is the first consumer.

## Verification

`yaml.safe_load` on the patched file: 9 jobs intact, the guard step lands
between `Restore previous database checkpoint` and `Init DB if missing or
corrupt` in `light`, and all four merge-job conditions parse as intended.

Recovery of the data path itself is separate: dispatch
`reseed-checkpoint-from-hf.yml` to put the 16.5GB canonical DB back at the head
of the artifact chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled backfill runs now stop early when the checkpoint chain cannot be restored, preventing rebuilds from an empty database.
  - Pipeline reporting and failure handling now correctly reflect upload failures and lost checkpoint chains.
  - Coverage reports and checkpoint artifacts are gated on successful upstream processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->