### PR TITLE
fix(backfill): verify restored base against the canonical row-count manifest

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1937,6 +1937,7 @@ jobs:
       snapshot_outcome: ${{ steps.snapshot.outcome }}
       restore_outcome: ${{ steps.restore.outcome }}
       restore_restored: ${{ steps.restore.outputs.restored }}
+      base_check: ${{ steps.base_check.outcome }}
 
     steps:
       # Free ~30GB of pre-installed software we never use, to keep the runner's
@@ -2187,6 +2188,20 @@ jobs:
               exit 1
             fi
           fi
+
+      # The guard above only catches restored=none. The restore loop can also
+      # return "<artifact>-salvaged" -- a per-table copy out of a corrupt
+      # checkpoint, table-incomplete by construction (the reseed workflow
+      # header describes an earlier degraded ~587MB salvage at the head of the
+      # chain). Compare the restored base against the row-count manifest
+      # hf_sync.py publishes next to the canonical DB, so a thin base stops the
+      # run before it spends ~3h fetching onto it. The dataset is public, so no
+      # token is needed; an unreachable manifest warns and passes.
+      - name: Verify the restored base against the canonical row-count manifest
+        id: base_check
+        if: github.event_name == 'schedule'
+        run: |
+          python3 scripts/check_base_rowcounts.py --src data/geohazard.db
 
       - name: Validate Earthdata credentials
         id: earthdata_check
@@ -3422,7 +3437,7 @@ jobs:
       - name: Create issue on failure
         if: >-
           always()
-          && (steps.hf_upload.outcome == 'failure' || needs.light.outputs.restore_restored == 'none' || !(github.event_name == 'schedule' && github.run_attempt == 1))
+          && (steps.hf_upload.outcome == 'failure' || needs.light.outputs.restore_restored == 'none' || needs.light.outputs.base_check == 'failure' || !(github.event_name == 'schedule' && github.run_attempt == 1))
           && (
             needs.light.outputs.fetch_earthquakes == 'failure' ||
             needs.light.outputs.fetch_tec_event == 'failure' ||
@@ -3458,7 +3473,8 @@ jobs:
             needs.light.outputs.fetch_ioc_dart == 'failure' ||
             steps.merge.outcome == 'failure' ||
             steps.hf_upload.outcome == 'failure' ||
-            needs.light.outputs.restore_restored == 'none'
+            needs.light.outputs.restore_restored == 'none' ||
+            needs.light.outputs.base_check == 'failure'
           )
         env:
           GH_TOKEN: ${{ github.token }}
@@ -3499,6 +3515,7 @@ jobs:
           [ "${{ steps.merge.outcome }}" = "failure" ] && FAILED="$FAILED merge"
           [ "${{ steps.hf_upload.outcome }}" = "failure" ] && FAILED="$FAILED hf_upload"
           [ "${{ needs.light.outputs.restore_restored }}" = "none" ] && FAILED="$FAILED checkpoint_chain_lost"
+          [ "${{ needs.light.outputs.base_check }}" = "failure" ] && FAILED="$FAILED degraded_base"
           FAILED=$(echo "$FAILED" | xargs)
 
           if [ -f data/geohazard.db ]; then

--- a/scripts/check_base_rowcounts.py
+++ b/scripts/check_base_rowcounts.py
@@ -1,0 +1,91 @@
+"""Verify a restored base DB against the canonical row-count manifest.
+
+The 2026-07-24 incident: the light job restored nothing, initialised an empty
+DB and silently rebuilt the canonical history from scratch. The guard added in
+PR #197 catches `restored=none`, but the restore loop has a second way to hand
+back a thin base -- `<artifact>-salvaged`, a per-table copy out of a corrupt
+checkpoint, which is table-incomplete by construction (the reseed workflow's
+header describes an earlier "degraded ~587MB salvage" sitting at the head of
+the chain).
+
+hf_sync.py already publishes the counts we need: after every verified upload it
+writes <path>.rowcounts.json next to the canonical DB on Hugging Face. The
+dataset is public, so the manifest is readable over plain HTTPS with no token.
+Backfill is append-only, so a restored base should never sit below the manifest.
+
+Exit 1 when a table regressed; exit 0 otherwise, including when the manifest is
+unreachable -- an outage at Hugging Face must not stop the pipeline.
+"""
+import argparse
+import json
+import sqlite3
+import sys
+import urllib.error
+import urllib.request
+
+MANIFEST_URL = "https://huggingface.co/datasets/{repo}/resolve/main/{path}.rowcounts.json"
+
+
+def remote_manifest(repo: str, path: str, timeout: int):
+    url = MANIFEST_URL.format(repo=repo, path=path)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return json.load(r)
+    except (urllib.error.URLError, ValueError, TimeoutError) as e:
+        print(f"::warning::row-count manifest unreachable ({e}) -- skipping base check")
+        return None
+
+
+def local_counts(src: str, tables):
+    conn = sqlite3.connect(src)
+    out = {}
+    try:
+        for t in tables:
+            try:
+                out[t] = conn.execute(f'SELECT COUNT(*) FROM "{t}"').fetchone()[0]
+            except sqlite3.Error:
+                out[t] = 0  # missing table reads as a total loss
+    finally:
+        conn.close()
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--src", required=True)
+    p.add_argument("--repo", default="yasumorishima/japan-geohazard")
+    p.add_argument("--path", default="geohazard.db")
+    p.add_argument("--min-fraction", type=float, default=0.95,
+                   help="matches hf_sync.py's guard")
+    p.add_argument("--timeout", type=int, default=60)
+    a = p.parse_args()
+
+    prev = remote_manifest(a.repo, a.path, a.timeout)
+    if not prev:
+        return 0
+
+    prev = {t: n for t, n in prev.items() if n > 0}
+    loc = local_counts(a.src, prev.keys())
+
+    regressed = [
+        f"{t}: base={loc[t]:,} < {a.min_fraction:.0%} of canonical {prev[t]:,}"
+        for t in sorted(prev)
+        if loc[t] < prev[t] * a.min_fraction
+    ]
+    print(f"checked {len(prev)} tables against {a.repo}/{a.path}.rowcounts.json")
+    if not regressed:
+        print("base row counts OK (no table below the canonical floor)")
+        return 0
+
+    for line in regressed:
+        print(f"  {line}")
+    print(
+        f"::error::restored base regressed in {len(regressed)} table(s) -- refusing "
+        "to fetch onto a degraded base. Run reseed-checkpoint-from-hf.yml to "
+        "restore the chain head from the Hugging Face canonical copy."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景
2026-07-24 のチェックポイント連鎖失効事故の追随対応。PR #197 の guard は `restored=none`（restore 完全失敗）だけを捕捉するが、restore ループにはもう一つの thin-base 経路がある: 破損チェックポイントからの per-table copy（`<artifact>-salvaged`）。これはテーブル不完全になり得るのに従来は素通りだった。

## 変更
- `scripts/check_base_rowcounts.py` 新規: 復元 base を hf_sync.py が HF に publish する `geohazard.db.rowcounts.json`（public・token 不要）と per-table 突合。95% floor は hf_sync.py の guard と同一。テーブル欠損は 0 行扱い。manifest 到達不能は warn して pass（HF 障害でパイプラインを止めない）。
- `backfill.yml` light job に `base_check` step（schedule のみ）: 劣化 base を検知したら ~3h の fetch を始める前に fail。
- issue 自動作成条件に `base_check == 'failure'`（`degraded_base`）を追加（attempt-1 抑制バイパス込み、#197 と同型）。

## 検証
- RPi5 でスモーク 2 経路 PASS（healthy base → exit 0 / 劣化 base → exit 1・::error 出力）
- パッチ base は master tip `2af1e66` と一致確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01182bVGNtKzVZFJ43ohKt4v