### PR TITLE
backfill: bound the artifact inventory by count, not by retention days

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2580,7 +2580,7 @@ jobs:
         with:
           name: backfill-light-${{ github.run_id }}
           path: data/geohazard.db
-          retention-days: 3
+          retention-days: 30
 
   # =====================================================================
   # FETCH-GNSS -- GNSS-TEC (Nagoya U. ISEE), split out of the light job so
@@ -3162,7 +3162,64 @@ jobs:
         with:
           name: backfill-checkpoint-${{ github.run_id }}
           path: data/geohazard.db
-          retention-days: 3
+          retention-days: 30
+
+      - name: Prune old artifacts (bound the storage inventory)
+        # Storage discipline (2026-08-06). retention-days is back to 30 so a
+        # stalled schedule can no longer expire the checkpoint chain -- that
+        # is exactly the 2026-07-24 incident (retention cut 30->3 while every
+        # scheduled run sat cancelled in the queue for 9 days, so the chain
+        # died and the base DB was rebuilt from empty, losing tec /
+        # nightlight / iss_lis_lightning). The inventory is bounded here by
+        # count instead of by time: keep the newest N copies of each prefix
+        # and delete the rest, so the newest chain link never disappears no
+        # matter how long the schedule stalls.
+        #
+        # Prefix policy:
+        #   backfill-checkpoint-  the cross-run chain           -> keep 3
+        #   backfill-light-       consumed by this run's merge  -> keep 2
+        #   backfill-modis-       consumed by this run's merge  -> keep 2
+        # The per-table overlays (so2 / cloud / snet / gnss / hinet) ARE
+        # reused across runs by the own-overlay fast path in the restore
+        # step, and total only ~25GB, so they are deliberately left alone.
+        # Deliberately NOT gated on the upload succeeding: while the
+        # account is over the storage quota every upload hard-fails, and
+        # gating here would mean the step that frees the space can never
+        # run. Keeping the newest N copies is what protects the chain, and
+        # that holds regardless of whether this run added a new one.
+        if: >-
+          (success() || failure())
+          && github.ref == 'refs/heads/master'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LIST="${RUNNER_TEMP}/artifacts.json"
+          gh api "repos/${REPO}/actions/artifacts?per_page=100" --paginate --slurp > "$LIST"
+          LIVE='[.[].artifacts[] | select(.expired == false and (.name | startswith($p)))]'
+          prune() {
+            PREFIX="$1"
+            KEEP="$2"
+            TOTAL=$(jq --arg p "$PREFIX" "${LIVE} | length" "$LIST")
+            echo "${PREFIX} : ${TOTAL} live (keep ${KEEP})"
+            if [ "$TOTAL" -le "$KEEP" ]; then
+              echo "  nothing to prune"
+              return 0
+            fi
+            IDS=$(jq -r --arg p "$PREFIX" --argjson k "$KEEP" "${LIVE} | sort_by(.created_at) | reverse | to_entries | map(select(.key >= \$k) | .value.id) | .[]" "$LIST")
+            for ID in $IDS; do
+              if gh api --method DELETE --silent "repos/${REPO}/actions/artifacts/${ID}"; then
+                echo "  deleted ${ID}"
+              else
+                echo "  ::warning::failed to delete artifact ${ID}"
+              fi
+            done
+          }
+          prune backfill-checkpoint- 3
+          prune backfill-light- 2
+          prune backfill-modis- 2
 
       - name: Notify Discord
         if: always()

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -3175,20 +3175,39 @@ jobs:
         # and delete the rest, so the newest chain link never disappears no
         # matter how long the schedule stalls.
         #
+        # KEEP is one full day of runs (merge runs on 8 crons/day), not a
+        # bare minimum. Two consumers need history, not just the newest:
+        #   - the restore step falls back to progressively older
+        #     backfill-checkpoint- artifacts when the newest one fails its
+        #     integrity check, so a systematic corruption needs more than
+        #     one or two links to survive;
+        #   - diagnose-merge.yml takes an arbitrary diag_run_id and pulls
+        #     backfill-light-<that run> / backfill-<kind>-<that run> to
+        #     isolate which overlay introduced a corruption (built for the
+        #     2026-05-08 Tree 98196 incident). Keeping only the newest
+        #     couple would leave ~6h to dispatch it after a bad merge.
+        # A day of headroom costs ~100GB against the ~614GB this replaces.
+        #
         # Prefix policy:
-        #   backfill-checkpoint-  the cross-run chain           -> keep 3
-        #   backfill-light-       consumed by this run's merge  -> keep 2
-        #   backfill-modis-       consumed by this run's merge  -> keep 2
+        #   backfill-checkpoint-  restore chain + fallback depth -> keep 8
+        #   backfill-light-       diagnose-merge evidence        -> keep 8
+        #   backfill-modis-       diagnose-merge evidence        -> keep 8
         # The per-table overlays (so2 / cloud / snet / gnss / hinet) ARE
         # reused across runs by the own-overlay fast path in the restore
-        # step, and total only ~25GB, so they are deliberately left alone.
+        # step, and total only ~25GB, so they are deliberately left alone
+        # on their 7-day retention.
         # Deliberately NOT gated on the upload succeeding: while the
         # account is over the storage quota every upload hard-fails, and
         # gating here would mean the step that frees the space can never
         # run. Keeping the newest N copies is what protects the chain, and
         # that holds regardless of whether this run added a new one.
+        # always(), not (success() || failure()): merge has been cancelled
+        # by its own 150m timeout before (runs 25276071313 / 25279499629),
+        # and prune is now the only thing bounding the inventory, so it has
+        # to run in the cancellation grace period too. Deleting only the
+        # copies older than the newest KEEP is safe at any job outcome.
         if: >-
-          (success() || failure())
+          always()
           && github.ref == 'refs/heads/master'
         continue-on-error: true
         env:
@@ -3217,9 +3236,9 @@ jobs:
               fi
             done
           }
-          prune backfill-checkpoint- 3
-          prune backfill-light- 2
-          prune backfill-modis- 2
+          prune backfill-checkpoint- 8
+          prune backfill-light- 8
+          prune backfill-modis- 8
 
       - name: Notify Discord
         if: always()


### PR DESCRIPTION
## なぜ

`retention-days: 3` は容量をチェックポイント鎖の寿命と引き換えにしていた。鎖はパイプラインの作業状態そのもの（各 run が最新の生きた `backfill-checkpoint-<run_id>` を restore して続きから積む）なので、retention が短いと schedule が止まった分だけ静かに鎖が死ぬ。これが 2026-07-24 の事故 — retention を 30→3 に切った直後に scheduled run が 9 日間キューで cancel され続け、鎖が失効して base DB が空から再構築され、`tec` / `nightlight` / `iss_lis_lightning` が消えた。

そもそも容量は日数ではなく「本数 × サイズ」（1 本 ~6.2GB、8 run/日）で決まる。

## 何をしたか

- `backfill-checkpoint-` / `backfill-light-` の `retention-days` を 3 → 30 に戻す（鎖の停止耐性を 1 か月に）
- `merge` job に "Prune old artifacts" step を新設。`backfill-checkpoint-` / `backfill-light-` / `backfill-modis-` それぞれ**最新 8 本（＝1 日ぶんの run）**を残して残りを削除

実在庫に対する dry-run 実測: **614GB → ~132GB**。checkpoint の保持 8 本は 2026-08-05T01:19Z〜2026-08-06T10:09Z ＝ 33 時間ぶん。

## 保持本数を 8 にした理由

最新 1〜2 本では足りない consumer が 2 つある:

- restore step は最新の checkpoint が integrity check に落ちると順に古い方へ fallback する。同日作成の 3 本では systematic な破損に耐えない。
- `diagnose-merge.yml` は任意の `diag_run_id` を取って `backfill-light-<その run>`（L49）と `backfill-<kind>-<その run>`（L129）を落とし、どの overlay が破損を持ち込んだか切り分ける（2026-05-08 Tree 98196 事故用）。最新 2 本だと bad merge の後 6 時間しか dispatch 猶予がなく、**artifact の削除は expire と違って証拠が復元不能**。

## 触っていないもの

per-table overlay（`so2` / `cloud` / `snet` / `gnss` / `hinet`）は各 fetch job の own-overlay fast path が run をまたいで使い、合計 ~25GB しかないので 7 日 retention のまま。

## 条件について

prune step は checkpoint upload の成否で gate していない。quota 超過中は upload が必ず hard fail するので、gate すると容量を空ける唯一の step が永久に走らない deadlock になる。鎖を守っているのは「最新 N 本を消さない」ことであって upload の成否ではない。

同じ理由で `(success() || failure())` ではなく `always()`。merge は自身の 150 分 timeout で cancelled になった実績があり（run 25276071313 / 25279499629）、cancelled はどちらの関数にも当たらない。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended artifact retention from 3 to 30 days for light and merged checkpoints.
  * Added automated cleanup to retain the eight newest checkpoint, light, and MODIS artifacts.
  * Cleanup now runs on the master branch even if earlier workflow steps fail or are cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->