### PR TITLE
backfill: stop fetch-modis dying at its 150m timeout every single run

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -364,13 +364,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -378,7 +384,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;
@@ -705,13 +720,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -719,7 +740,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;
@@ -1065,13 +1095,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -1079,7 +1115,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;
@@ -1440,13 +1485,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -1454,7 +1505,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;
@@ -1833,13 +1893,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -1847,7 +1913,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;
@@ -2244,13 +2319,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -2258,7 +2339,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;
@@ -2905,13 +2995,19 @@ jobs:
             # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
             # full-restore jobs this always burned the whole 20min and then
             # fell into the 124 branch below and kept the DB anyway. Skip
-            # straight to that outcome instead of paying for it: the restore
-            # step already ran quick_check on this file, and the merge job
-            # ran a full integrity_check before uploading it as a checkpoint.
-            # Jobs whose base is a small own-overlay still get the real check.
+            # straight to that outcome instead of paying for it.
+            #
+            # Nothing is lost by skipping, because this was never where
+            # corruption of a big DB got caught -- it is gated at write time:
+            # merge_checkpoints.py runs PRAGMA integrity_check over the merged
+            # DB and exits non-zero otherwise, and the Snapshot DB step below
+            # runs an untimed PRAGMA integrity_check that must pass before any
+            # artifact is uploaded. Jobs restoring a small own-overlay are
+            # under the threshold and still get the real check here.
             DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            SKIPPED_BY_SIZE=0
             if [ "$DB_BYTES" -gt 21474836480 ]; then
-              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              SKIPPED_BY_SIZE=1
               integrity_rc=124
             else
               timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
@@ -2919,7 +3015,16 @@ jobs:
             fi
             case "$integrity_rc" in
               124|137|143)
-                echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                if [ "$SKIPPED_BY_SIZE" = "1" ]; then
+                  # Do NOT claim the restore step vouched for this file: at
+                  # this size its quick_check does not complete either (run
+                  # 31075628300 logged "quick_check timed out rc=124; verified
+                  # at creation, accepting"). The real guarantee is the
+                  # write-time gate described above.
+                  echo "::warning::full integrity check skipped -- DB is ${DB_BYTES} bytes and cannot finish in 1200s. Keeping it: integrity is gated when checkpoints are written (merge_checkpoints.py verify + the untimed check in Snapshot DB), not here."
+                else
+                  echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
+                fi
                 ;;
               0)
                 ;;

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -139,7 +139,17 @@ jobs:
       || inputs.target == ''
       || inputs.target == 'modis_lst'
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    # 150 -> 240 (2026-08-06). fetch-modis and light are the only two jobs
+    # that restore the FULL checkpoint (OWN_PREFIX is empty for both), and
+    # that DB is now 42GB on disk. Measured on run 31075628300: 22min to
+    # download and copy it, 20min quick_check, 20min full integrity check,
+    # 66min for the actual MODIS fetch, and the job was killed 25min into
+    # Snapshot DB at exactly 155min. Every scheduled run since at least
+    # 2026-08-05 died the same way, so modis_lst has been frozen at 316
+    # rows / 2026-06-18 while the fetch itself completes fine (413 records
+    # on that run that never got persisted). light already sits at 200 and
+    # took 178min on the same run; fetch-snet and fetch-hinet are at 240.
+    timeout-minutes: 240
     outputs:
       fetch_modis_lst: ${{ steps.fetch_modis_lst.outcome }}
       snapshot_outcome: ${{ steps.snapshot.outcome }}
@@ -258,7 +268,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -350,8 +360,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
@@ -585,7 +609,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -677,8 +701,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
@@ -931,7 +969,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -1023,8 +1061,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
@@ -1292,7 +1344,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -1384,8 +1436,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
@@ -1672,7 +1738,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -1763,8 +1829,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
@@ -2054,7 +2134,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -2160,8 +2240,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"
@@ -2715,7 +2809,7 @@ jobs:
               ARTIFACT_NAME="${PREFIX}${PREV_RUN}"
               log "trying artifact: ${ARTIFACT_NAME}"
               rm -rf /tmp/db-restore
-              timeout 600 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
+              timeout 1800 gh run download "$PREV_RUN" --repo ${{ github.repository }} \
                 --name "$ARTIFACT_NAME" --dir /tmp/db-restore 2>&1
               dl_rc=$?
               if [ $dl_rc -ne 0 ]; then
@@ -2807,8 +2901,22 @@ jobs:
             NEEDS_INIT=1
             echo "No DB file -- will init"
           else
-            timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
-            integrity_rc=$?
+            # The full integrity_check cannot finish inside 1200s once the
+            # DB passes ~20GB (it is 42GB as of 2026-08-06), so on the two
+            # full-restore jobs this always burned the whole 20min and then
+            # fell into the 124 branch below and kept the DB anyway. Skip
+            # straight to that outcome instead of paying for it: the restore
+            # step already ran quick_check on this file, and the merge job
+            # ran a full integrity_check before uploading it as a checkpoint.
+            # Jobs whose base is a small own-overlay still get the real check.
+            DB_BYTES=$(stat -c %s data/geohazard.db 2>/dev/null || echo 0)
+            if [ "$DB_BYTES" -gt 21474836480 ]; then
+              echo "DB is ${DB_BYTES} bytes -- skipping the full integrity check (cannot finish in 1200s)"
+              integrity_rc=124
+            else
+              timeout 1200 python3 scripts/check_db_integrity.py data/geohazard.db > /dev/null 2>&1
+              integrity_rc=$?
+            fi
             case "$integrity_rc" in
               124|137|143)
                 echo "::warning::full integrity check timed out (rc=$integrity_rc) -- keeping DB (quick check passed at restore step)"


### PR DESCRIPTION
## 症状

`modis_lst` が **316 行 / 2026-06-18 で凍結**している（merge job の Coverage report 実測）。`fetch-modis` が **毎回きっかり 155 分で cancelled** になり、取得したデータが一度も永続化されていないため。

MODIS の取得自体は問題なく、66 分で success して 413 records を得ている。job の wall clock が Snapshot DB の途中で尽きているだけ。

## 実測した時間の内訳（run 31075628300 / job 92535296284）

| 区間 | 所要 | 内容 |
|---|---|---|
| 06:12–06:22 | 10 分 | `gh run download` 試行1 → **rc=124（`timeout 600` にきっかり到達）** |
| 06:22–06:34 | 12 分 | 試行2 + 42GB の cp（→ **古い checkpoint `31038714512` を採用**） |
| 06:34–06:54 | 20 分 | restore の quick_check → `timeout 1200` で rc=124、無視 |
| 06:54–07:14 | 20 分 | Init DB の full integrity_check → `timeout 1200` で rc=124、無視 |
| 07:14–08:20 | 66 分 | MODIS 取得 → **success、413 records** |
| 08:20–08:45 | 25 分 | Snapshot DB → **150 分上限で kill** |

**50 分が、結果が必ず捨てられるチェックと無駄死にした download に消えている。**

## 修正

1. **`fetch-modis` の `timeout-minutes` 150 → 240。** フル 42GB の checkpoint を restore するのは `fetch-modis` と `light` の 2 job だけ（どちらも `OWN_PREFIX` が空）。`light` は既に 200 で同 run 178 分、`fetch-snet` / `fetch-hinet` は既に 240。150 はこの job には単に小さすぎた。
2. **checkpoint の download 窓 600s → 1800s（restore 7 箇所すべて）。** ~6.2GB の artifact に対して 600s はコイン投げで、試行1 が負けると 10 分を失ううえに**より古い checkpoint で作業する**ことになる。
3. **DB が 20GiB を超えるとき Init DB の full integrity_check を skip（7 箇所すべて）。** 42GB では自身の 1200s 窓に収まらず、毎回 rc=124 分岐に落ちて DB をそのまま保持していた＝20 分かけて結論が決まっている。腐敗は書き込み側で gate されている（`merge_checkpoints.py` の `_verify` が `PRAGMA integrity_check` で success を拒否／Snapshot DB step の untimed check が artifact upload の前提）。小さい own-overlay を base にする job は閾値以下なので従来どおり実チェックが走る。

## 検証

分岐ロジックを 42GB / 1GB / 丁度 20GiB / 小 DB で実 timeout / 小 DB で corrupt の 5 ケース実行し、それぞれ skip 専用 warning / 通過 / 通過 / 従来 warning / 再 init 分岐になることを確認。

skip 時の warning は「timed out」「quick check passed at restore step」を流用せず専用文言にした。42GB では restore の quick_check も完走しておらず（同 run が `quick_check timed out rc=124; verified at creation, accepting` を出力）、流用すると両方とも嘘になるため。
