### PR TITLE
backfill: fetch jobs must not silently fetch onto an empty base

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -3649,6 +3649,10 @@ jobs:
           RESTORED_CLOUD: ${{ needs.fetch-cloud.outputs.restore_restored }}
           RESTORED_SNET: ${{ needs.fetch-snet.outputs.restore_restored }}
           RESTORED_LIGHT: ${{ needs.light.outputs.restore_restored }}
+          RESTORE_HINET: ${{ needs.fetch-hinet.outputs.restore_outcome }}
+          RESTORE_GNSS: ${{ needs.fetch-gnss.outputs.restore_outcome }}
+          RESTORED_HINET: ${{ needs.fetch-hinet.outputs.restore_restored }}
+          RESTORED_GNSS: ${{ needs.fetch-gnss.outputs.restore_restored }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then exit 0; fi
           # When the merge step failed (e.g. base missing under --require-base),
@@ -3663,12 +3667,16 @@ jobs:
               'fetch-so2:   ' + os.environ.get('FETCH_SO2_RESULT', 'unknown') + '\n'
               'fetch-cloud: ' + os.environ.get('FETCH_CLOUD_RESULT', 'unknown') + '\n'
               'fetch-snet:  ' + os.environ.get('FETCH_SNET_RESULT', 'unknown') + '\n'
+              'fetch-hinet: ' + os.environ.get('FETCH_HINET_RESULT', 'unknown') + '\n'
+              'fetch-gnss:  ' + os.environ.get('FETCH_GNSS_RESULT', 'unknown') + '\n'
               'light:       ' + os.environ.get('LIGHT_RESULT', 'unknown') + '\n'
               'merge:       ' + os.environ.get('MERGE_OUTCOME', 'unknown') + '\n\n'
               'restore modis: ' + os.environ.get('RESTORE_MODIS', '?') + ' (' + os.environ.get('RESTORED_MODIS', '?') + ')\n'
               'restore so2:   ' + os.environ.get('RESTORE_SO2', '?') + ' (' + os.environ.get('RESTORED_SO2', '?') + ')\n'
               'restore cloud: ' + os.environ.get('RESTORE_CLOUD', '?') + ' (' + os.environ.get('RESTORED_CLOUD', '?') + ')\n'
               'restore snet:  ' + os.environ.get('RESTORE_SNET', '?') + ' (' + os.environ.get('RESTORED_SNET', '?') + ')\n'
+              'restore hinet: ' + os.environ.get('RESTORE_HINET', '?') + ' (' + os.environ.get('RESTORED_HINET', '?') + ')\n'
+              'restore gnss:  ' + os.environ.get('RESTORE_GNSS', '?') + ' (' + os.environ.get('RESTORED_GNSS', '?') + ')\n'
               'restore light: ' + os.environ.get('RESTORE_LIGHT', '?') + ' (' + os.environ.get('RESTORED_LIGHT', '?') + ')\n'
               '\nNo merged DB to report coverage from.'
           )

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -365,7 +365,8 @@ jobs:
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
@@ -743,7 +744,8 @@ jobs:
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
@@ -1140,7 +1142,8 @@ jobs:
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
@@ -1552,7 +1555,8 @@ jobs:
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
@@ -1983,7 +1987,8 @@ jobs:
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
@@ -2409,7 +2414,8 @@ jobs:
       # instead: reseed the chain from Hugging Face, then let the cron resume.
       - name: Guard against rebuilding the base DB from empty
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to rebuild the base DB from empty on a scheduled run. Run reseed-checkpoint-from-hf.yml to restore the chain from the Hugging Face canonical copy, then let the schedule resume."
@@ -3107,7 +3113,8 @@ jobs:
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
         if: >-
-          steps.restore.outputs.restored == 'none'
+          (steps.restore.outputs.restored == 'none'
+           || steps.restore.outputs.restored == '')
           && github.event_name == 'schedule'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
@@ -3630,6 +3637,8 @@ jobs:
           FETCH_CLOUD_RESULT: ${{ needs.fetch-cloud.result }}
           FETCH_SNET_RESULT: ${{ needs.fetch-snet.result }}
           LIGHT_RESULT: ${{ needs.light.result }}
+          FETCH_HINET_RESULT: ${{ needs.fetch-hinet.result }}
+          FETCH_GNSS_RESULT: ${{ needs.fetch-gnss.result }}
           RESTORE_MODIS: ${{ needs.fetch-modis.outputs.restore_outcome }}
           RESTORE_SO2: ${{ needs.fetch-so2.outputs.restore_outcome }}
           RESTORE_CLOUD: ${{ needs.fetch-cloud.outputs.restore_outcome }}
@@ -3774,6 +3783,17 @@ jobs:
               'Restore cloud': os.environ.get('RESTORE_CLOUD', 'skipped'),
               'Restore snet': os.environ.get('RESTORE_SNET', 'skipped'),
               'Restore light': os.environ.get('RESTORE_LIGHT', 'skipped'),
+              # Job-level results: the guard step that refuses to fetch
+              # onto an empty base fails the JOB while the restore STEP
+              # itself reports success, so without these a guarded run
+              # reports green here.
+              'Job modis': os.environ.get('FETCH_MODIS_RESULT', 'skipped'),
+              'Job so2': os.environ.get('FETCH_SO2_RESULT', 'skipped'),
+              'Job cloud': os.environ.get('FETCH_CLOUD_RESULT', 'skipped'),
+              'Job snet': os.environ.get('FETCH_SNET_RESULT', 'skipped'),
+              'Job hinet': os.environ.get('FETCH_HINET_RESULT', 'skipped'),
+              'Job gnss': os.environ.get('FETCH_GNSS_RESULT', 'skipped'),
+              'Job light': os.environ.get('LIGHT_RESULT', 'skipped'),
           }
           failed_steps = [k for k, v in step_results.items() if v == 'failure']
           if failed_steps:
@@ -3896,7 +3916,14 @@ jobs:
             steps.merge.outcome == 'failure' ||
             steps.hf_upload.outcome == 'failure' ||
             needs.light.outputs.restore_restored == 'none' ||
-            needs.light.outputs.base_check == 'failure'
+            needs.light.outputs.base_check == 'failure' ||
+            needs.fetch-modis.result == 'failure' ||
+            needs.fetch-so2.result == 'failure' ||
+            needs.fetch-cloud.result == 'failure' ||
+            needs.fetch-snet.result == 'failure' ||
+            needs.fetch-hinet.result == 'failure' ||
+            needs.fetch-gnss.result == 'failure' ||
+            needs.light.result == 'failure'
           )
         env:
           GH_TOKEN: ${{ github.token }}
@@ -3938,6 +3965,9 @@ jobs:
           [ "${{ steps.hf_upload.outcome }}" = "failure" ] && FAILED="$FAILED hf_upload"
           [ "${{ needs.light.outputs.restore_restored }}" = "none" ] && FAILED="$FAILED checkpoint_chain_lost"
           [ "${{ needs.light.outputs.base_check }}" = "failure" ] && FAILED="$FAILED degraded_base"
+          for jr in "fetch-modis:${{ needs.fetch-modis.result }}" "fetch-so2:${{ needs.fetch-so2.result }}" "fetch-cloud:${{ needs.fetch-cloud.result }}" "fetch-snet:${{ needs.fetch-snet.result }}" "fetch-hinet:${{ needs.fetch-hinet.result }}" "fetch-gnss:${{ needs.fetch-gnss.result }}" "light:${{ needs.light.result }}"; do
+            [ "${jr#*:}" = "failure" ] && FAILED="$FAILED job:${jr%%:*}"
+          done
           FAILED=$(echo "$FAILED" | xargs)
 
           if [ -f data/geohazard.db ]; then

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -349,6 +349,28 @@ jobs:
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
 
+      - name: Guard against rebuilding the base DB from empty
+        # light has had this guard since the 2026-07-24 incident; the fetch
+        # jobs never got it, and that is exactly how run 31084273068 went
+        # green while doing nothing: fetch-modis spent 50min losing five
+        # 600s checkpoint downloads in a row (rc=124 each), fell through to
+        # "No usable checkpoint found -- will init fresh DB", fetched 0
+        # records from an empty base and uploaded a 159744-byte overlay.
+        # merge_checkpoints.py caught it at merge time (overlay_count <
+        # before -> "overlay empty ... KEEPING base"), so no data was lost,
+        # but the job reported success and the real failure was invisible
+        # until someone read the restore log.
+        #
+        # Failing here is safe for the pipeline: merge runs with
+        # `if: always()` and each overlay download is continue-on-error, so
+        # a red fetch job costs its own table for one cron, not the chain.
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
+          exit 1
+
       - name: Init DB if missing or corrupt
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
@@ -704,6 +726,28 @@ jobs:
           fi
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
+
+      - name: Guard against rebuilding the base DB from empty
+        # light has had this guard since the 2026-07-24 incident; the fetch
+        # jobs never got it, and that is exactly how run 31084273068 went
+        # green while doing nothing: fetch-modis spent 50min losing five
+        # 600s checkpoint downloads in a row (rc=124 each), fell through to
+        # "No usable checkpoint found -- will init fresh DB", fetched 0
+        # records from an empty base and uploaded a 159744-byte overlay.
+        # merge_checkpoints.py caught it at merge time (overlay_count <
+        # before -> "overlay empty ... KEEPING base"), so no data was lost,
+        # but the job reported success and the real failure was invisible
+        # until someone read the restore log.
+        #
+        # Failing here is safe for the pipeline: merge runs with
+        # `if: always()` and each overlay download is continue-on-error, so
+        # a red fetch job costs its own table for one cron, not the chain.
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
+          exit 1
 
       - name: Init DB if missing or corrupt
         env:
@@ -1079,6 +1123,28 @@ jobs:
           fi
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
+
+      - name: Guard against rebuilding the base DB from empty
+        # light has had this guard since the 2026-07-24 incident; the fetch
+        # jobs never got it, and that is exactly how run 31084273068 went
+        # green while doing nothing: fetch-modis spent 50min losing five
+        # 600s checkpoint downloads in a row (rc=124 each), fell through to
+        # "No usable checkpoint found -- will init fresh DB", fetched 0
+        # records from an empty base and uploaded a 159744-byte overlay.
+        # merge_checkpoints.py caught it at merge time (overlay_count <
+        # before -> "overlay empty ... KEEPING base"), so no data was lost,
+        # but the job reported success and the real failure was invisible
+        # until someone read the restore log.
+        #
+        # Failing here is safe for the pipeline: merge runs with
+        # `if: always()` and each overlay download is continue-on-error, so
+        # a red fetch job costs its own table for one cron, not the chain.
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
+          exit 1
 
       - name: Init DB if missing or corrupt
         env:
@@ -1469,6 +1535,28 @@ jobs:
           fi
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
+
+      - name: Guard against rebuilding the base DB from empty
+        # light has had this guard since the 2026-07-24 incident; the fetch
+        # jobs never got it, and that is exactly how run 31084273068 went
+        # green while doing nothing: fetch-modis spent 50min losing five
+        # 600s checkpoint downloads in a row (rc=124 each), fell through to
+        # "No usable checkpoint found -- will init fresh DB", fetched 0
+        # records from an empty base and uploaded a 159744-byte overlay.
+        # merge_checkpoints.py caught it at merge time (overlay_count <
+        # before -> "overlay empty ... KEEPING base"), so no data was lost,
+        # but the job reported success and the real failure was invisible
+        # until someone read the restore log.
+        #
+        # Failing here is safe for the pipeline: merge runs with
+        # `if: always()` and each overlay download is continue-on-error, so
+        # a red fetch job costs its own table for one cron, not the chain.
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
+          exit 1
 
       - name: Init DB if missing or corrupt
         env:
@@ -1878,6 +1966,29 @@ jobs:
           fi
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
+
+      - name: Guard against rebuilding the base DB from empty
+        # light has had this guard since the 2026-07-24 incident; the fetch
+        # jobs never got it, and that is exactly how run 31084273068 went
+        # green while doing nothing: fetch-modis spent 50min losing five
+        # 600s checkpoint downloads in a row (rc=124 each), fell through to
+        # "No usable checkpoint found -- will init fresh DB", fetched 0
+        # records from an empty base and uploaded a 159744-byte overlay.
+        # merge_checkpoints.py caught it at merge time (overlay_count <
+        # before -> "overlay empty ... KEEPING base"), so no data was lost,
+        # but the job reported success and the real failure was invisible
+        # until someone read the restore log.
+        #
+        # Failing here is safe for the pipeline: merge runs with
+        # `if: always()` and each overlay download is continue-on-error, so
+        # a red fetch job costs its own table for one cron, not the chain.
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
+          exit 1
+
       - name: Init DB if missing or corrupt
         env:
           GEOHAZARD_DB_PATH: ./data/geohazard.db
@@ -2979,6 +3090,28 @@ jobs:
           fi
           log "restore step done (RESTORED=${RESTORED:-none})"
           exit 0
+
+      - name: Guard against rebuilding the base DB from empty
+        # light has had this guard since the 2026-07-24 incident; the fetch
+        # jobs never got it, and that is exactly how run 31084273068 went
+        # green while doing nothing: fetch-modis spent 50min losing five
+        # 600s checkpoint downloads in a row (rc=124 each), fell through to
+        # "No usable checkpoint found -- will init fresh DB", fetched 0
+        # records from an empty base and uploaded a 159744-byte overlay.
+        # merge_checkpoints.py caught it at merge time (overlay_count <
+        # before -> "overlay empty ... KEEPING base"), so no data was lost,
+        # but the job reported success and the real failure was invisible
+        # until someone read the restore log.
+        #
+        # Failing here is safe for the pipeline: merge runs with
+        # `if: always()` and each overlay download is continue-on-error, so
+        # a red fetch job costs its own table for one cron, not the chain.
+        if: >-
+          steps.restore.outputs.restored == 'none'
+          && github.event_name == 'schedule'
+        run: |
+          echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
+          exit 1
 
       - name: Init DB if missing or corrupt
         env:


### PR DESCRIPTION
## きっかけ

直前の timeout 修正（#200）を検証していて、同じ job のもっと静かな壊れ方を見つけた。run 31084273068 の `fetch-modis` は **52 分で success** を報告しているが中身が無い:

```
10:14:26-11:04:35  restore -- checkpoint download が 5 連続 rc=124（各 600s）
                   → database-checkpoint- の fallback も 404
                   → "No usable checkpoint found -- will init fresh DB"
11:04:35  Init DB        1秒（空 DB）
11:04:36  Fetch MODIS    0秒 "TOTAL: 0 earthquake + 0 control = 0 LST records"
11:04:37  Snapshot       1秒（159744 バイト）
11:04:39  Upload modis.db artifact → 緑
```

**データは失われていない。** `scripts/merge_checkpoints.py` が owned table の行数が base より少ない overlay を拒否する（`overlay empty ... KEEPING base`。2026-04-18 の `cloud_fraction` 523K→0 を受けて入った guard）。だが job が緑なので、50 分ぶんの download 失敗は restore のログを開かない限り見えなかった。

`light` は 2026-07-24 の事故以降この guard を持っている。**6 つの fetch job には無かった。**

## 変更

1. **6 つの fetch job に `Guard against rebuilding the base DB from empty` を追加**（restore と Init DB の間、`light` と同じ位置）。
2. **guard の条件を `'none'` だけでなく `''` でも発火するように**（7 job すべて。`light` にも同じ穴があった）。restore step は `continue-on-error: true` + `timeout-minutes: 90` で、`restored=none` は最終行でしか書かれない。90 分で kill されると output は空になり `== 'none'` に当たらない。**download 窓を 1800s にした今、hung download 3 本で 90 分に届く**ので、これが主経路になる。
3. **guard 発火を Discord と Issue に配線**。`RESTORE_*` は restore *step* の outcome なので、step 成功・guard 失敗だと `success` のまま。`fetch_*` output も後続 step が走らないので `skipped` であって `failure` ではない。結果としてどちらの通知経路にも出ていなかった＝「ログを開かないと見えない」を直すはずの変更が通知に届いていなかった。
   - Discord: job 単位の結果 7 件を `step_results` に追加（`FETCH_HINET_RESULT` / `FETCH_GNSS_RESULT` の env も新設）
   - Issue: 条件と `FAILED` 文字列に `needs.<job>.result == 'failure'` を 7 件追加。target filter で除外された job は `'skipped'` なので targeted dispatch では発火しない。
4. **merge-skipped 時の Discord embed に hinet / gnss の行を追加**（7 job 中 5 job しか出ていなかった）。

## なぜ fail させて安全か

`merge` は `if: always()` で走り、各 overlay の download は `continue-on-error: true`。赤い fetch job のコストは「その job の table が 1 cron ぶん進まない」ことであって、checkpoint 鎖ではない。

## 検証

- 7 job すべてで guard がちょうど 1 個、restore と Init DB の間に配置
- 変更した `run:` ブロックすべて `bash -n` rc=0
- `Notify Discord` の `python3 -c` ブロック 2 つとも `compile()` 通過
- `FAILED` のループは `bash -e` 下で、最後に評価した job が failure でない場合も rc=0（`&&` リストの失敗は errexit の対象外であることを実行して確認）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled fetch jobs now fail clearly when checkpoint data cannot be restored, instead of starting with an empty database.
  * Improved handling of empty checkpoint restoration results.
* **Notifications**
  * Failure alerts and issue reports now include results for Hi-net, GNSS, and individual fetch jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->