### PR TITLE
backfill: close the master-dispatch route into an empty/thin checkpoint

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -2496,7 +2496,7 @@ jobs:
            || steps.restore.outputs.restored == '')
           && github.ref == 'refs/heads/master'
         run: |
-          echo "::error::No usable checkpoint artifact -- refusing to rebuild the base DB from empty on a scheduled run. Run reseed-checkpoint-from-hf.yml to restore the chain from the Hugging Face canonical copy, then let the schedule resume."
+          echo "::error::No usable checkpoint artifact -- refusing to rebuild the base DB from empty on master. Run reseed-checkpoint-from-hf.yml to restore the chain from the Hugging Face canonical copy, then let the schedule resume."
           exit 1
 
       - name: Init DB if missing or corrupt

--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -364,10 +364,23 @@ jobs:
         # Failing here is safe for the pipeline: merge runs with
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
           exit 1
@@ -743,10 +756,23 @@ jobs:
         # Failing here is safe for the pipeline: merge runs with
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
           exit 1
@@ -1141,10 +1167,23 @@ jobs:
         # Failing here is safe for the pipeline: merge runs with
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
           exit 1
@@ -1554,10 +1593,23 @@ jobs:
         # Failing here is safe for the pipeline: merge runs with
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
           exit 1
@@ -1986,10 +2038,23 @@ jobs:
         # Failing here is safe for the pipeline: merge runs with
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
           exit 1
@@ -2413,10 +2478,23 @@ jobs:
       # HF row-count guard has been refusing to publish ever since. Fail loudly
       # instead: reseed the chain from Hugging Face, then let the cron resume.
       - name: Guard against rebuilding the base DB from empty
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to rebuild the base DB from empty on a scheduled run. Run reseed-checkpoint-from-hf.yml to restore the chain from the Hugging Face canonical copy, then let the schedule resume."
           exit 1
@@ -2500,7 +2578,13 @@ jobs:
       # token is needed; an unreachable manifest warns and passes.
       - name: Verify the restored base against the canonical row-count manifest
         id: base_check
-        if: github.event_name == 'schedule'
+        # Ref-keyed for the same reason as the empty-base guard above: a
+        # scheduled run is always on the default branch, and a master
+        # dispatch with target all/'' is allowed to upload a checkpoint, so a
+        # thin base there would become the next base just as surely as on a
+        # cron. A feature-branch dispatch legitimately carries a partial DB
+        # and cannot upload a checkpoint, so it stays exempt.
+        if: github.ref == 'refs/heads/master'
         run: |
           python3 scripts/check_base_rowcounts.py --src data/geohazard.db
 
@@ -3112,10 +3196,23 @@ jobs:
         # Failing here is safe for the pipeline: merge runs with
         # `if: always()` and each overlay download is continue-on-error, so
         # a red fetch job costs its own table for one cron, not the chain.
+        # Keyed on the ref, not the event. A scheduled run always runs on the
+        # default branch (the checkpoint upload step relies on the same fact),
+        # so this still covers every cron -- but it now also covers a manual
+        # dispatch on master, which was the remaining way to put an empty DB at
+        # the head of the chain: a master dispatch with target all/'' is
+        # explicitly allowed to upload a checkpoint, so running it while the
+        # chain is gone would make the empty base the next base, and every
+        # later scheduled run would then see restored != 'none' and sail past
+        # this guard. A dispatch on a feature branch cannot upload a
+        # checkpoint and is left free to smoke-test from nothing.
+        #
+        # If the chain really is gone, reseed-checkpoint-from-hf.yml is the
+        # way back -- not a dispatch of this workflow.
         if: >-
           (steps.restore.outputs.restored == 'none'
            || steps.restore.outputs.restored == '')
-          && github.event_name == 'schedule'
+          && github.ref == 'refs/heads/master'
         run: |
           echo "::error::No usable checkpoint artifact -- refusing to fetch onto an empty base. This overlay would be rejected as a shrink at merge time, so the fetch would be wasted. Check the restore log for rc=124 download timeouts; if the chain is genuinely gone, run reseed-checkpoint-from-hf.yml."
           exit 1


### PR DESCRIPTION
## 塞いだ穴

`Guard against rebuilding the base DB from empty`（7 job）と `light` の `base_check` は、どちらも `github.event_name == 'schedule'` で条件付けされていた。そのため**鎖が失効している状態で master 上で `workflow_dispatch` すると guard が無効**になる。master dispatch（target `all` / 未指定）は checkpoint upload を明示的に許可されているので、その空/薄い base が次の base になり、**以後の scheduled run は `restored != 'none'` になって guard を素通りする**。

## 変更

両方を `github.ref == 'refs/heads/master'` に変更しただけ。

- **cron のカバレッジは不変** — scheduled run は必ず default branch で走る（同ファイルの checkpoint upload step のコメントが既にこの事実に依存している。`default_branch` が `master` であることも API で確認）
- **feature branch の dispatch は対象外のまま** — 部分的な DB を持つのが正当で、`Upload checkpoint artifact` の `github.ref == 'refs/heads/master'` 節により鎖を汚染できない
- `light` の guard メッセージが「on a scheduled run」のままだったので「on master」に修正

## master targeted dispatch で壊れないこと

`base_check` は `light` の途中で走るので、targeted dispatch（例 `target=cloud`）でも実行されるようになる。

- base が健全なら pass（COUNT のコストは cron で毎回既払い）
- base が本当に thin なら light が fail → merge の Merge step は `needs.light.result == 'success'` で skip → snapshot skip → checkpoint upload は `steps.snapshot.outcome == 'success'` が必須なので skip → **鎖は無傷で、次の cron が前の checkpoint から再開**

つまり止まるだけで汚染しない。狙った保護そのもの。

`target=diagnostic` では `light` / 7 fetch job / `merge` すべてが job ごと skip されるので guard には触れない。

## 意図的に変えなかったもの

- 日次 HF upload（`ref == master && event == schedule && github.event.schedule == '0 0 * * *'`）— 手動 push は `hf-upload-checkpoint.yml` を使う
- 失敗 fetch job の auto-rerun（schedule 限定）— manual dispatch は manual のまま
