### PR TITLE
reseed: size the budget for the DB that actually exists

### DIFF
--- a/.github/workflows/reseed-checkpoint-from-hf.yml
+++ b/.github/workflows/reseed-checkpoint-from-hf.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Free up runner disk for the ~42GB DB
+      - name: Free up runner disk for the ~42 GiB DB
         run: |
           df -h /
           sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \

--- a/.github/workflows/reseed-checkpoint-from-hf.yml
+++ b/.github/workflows/reseed-checkpoint-from-hf.yml
@@ -4,8 +4,9 @@ name: Reseed checkpoint from Hugging Face
 # dataset and re-publish it as a fresh backfill-checkpoint-<run_id> artifact.
 #
 # Why: after the RPi5 SSD died (2026-05-27) the GitHub artifact chain's latest
-# surviving checkpoint was a degraded ~587MB salvage, while the full ~16.5GB
-# history lives only on HF. Running this once puts a complete checkpoint back
+# surviving checkpoint was a degraded ~587MB salvage, while the full history
+# lives only on HF -- ~16.5GB then, 44,614,766,592 bytes (41.55 GiB) as of
+# 2026-08-06. Running this once puts a complete checkpoint back
 # at the head of the chain (newest created_at), so the normal backfill restore
 # step (sort_by(created_at)|reverse) picks it up and the pipeline resumes from
 # full history instead of the degraded remnant.
@@ -22,7 +23,17 @@ on:
 jobs:
   reseed:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 60 -> 120 (2026-08-06). This is the only recovery path when the
+    # checkpoint chain is gone, so it runs exactly when a budget overrun
+    # would hurt most -- and its two dominant steps both scale with a DB
+    # that grows every day. The one successful reseed (run 30431629728,
+    # 2026-07-29) took 41m05s of the 60: disk 30s, HF download 2m16s,
+    # integrity check 25m14s, artifact upload 12m58s. A 19-minute margin
+    # against a growing input is the same mis-sized budget that had
+    # fetch-modis dying every run until 2026-08-06; size it once, here,
+    # rather than discover it during an outage. Public repo, so the
+    # unused ceiling costs nothing.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 
@@ -30,7 +41,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Free up runner disk for the 16.5GB DB
+      - name: Free up runner disk for the ~42GB DB
         run: |
           df -h /
           sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet \


### PR DESCRIPTION
## なぜ今か

checkpoint 鎖は現在 9 本すべて **retention 3 日**（修正前の run が上げたもの。`retention-days: 30` は新 workflow の run が上げた artifact にしか効かない）で、最新は **2026-08-09T14:10:05Z 失効**。GitHub Actions は 2026-08-06 15:22 UTC から critical incident が続いていて、30 日版に置き換える run を 1 本も通せていない。

障害が鎖より長引いた場合、これが唯一の復旧手段になる。**しかもこの workflow は `retention-days: 30` で上げるので、1 回成功すればこの露出は消える。**

## 何を直したか

`timeout-minutes` を **60 → 120**。

唯一の成功実績（run 30431629728、2026-07-29）は 60 分中 **41分05秒**:

| step | 所要 |
|---|---|
| Free up runner disk | 30 秒 |
| Download canonical DB from HF | 2分16秒 |
| **Integrity check** | **25分14秒** |
| **Upload as fresh checkpoint** | **12分58秒** |

支配的な 2 step は DB サイズに比例し、DB は毎日育つ。余裕 19 分（32%）は、**今日 `fetch-modis` を毎 run 殺していたのと同じ「実態に対して小さい budget」**。走らせるのは鎖が失効した非常時＝失敗を発見する最悪のタイミングなので、先に直す。public repo なので使わない上限のコストはゼロ。

## ついでに直した stale な記述

正本 DB は HF の `x-linked-size` 実測で **44,614,766,592 バイト（41.55 GiB）**。ヘッダコメントと disk cleanup step 名が残していた `~16.5GB` は、README の 2026-07-24 incident 節が既に指摘していたのと同じ古い数字。

## 補足

今日 backfill 側で観測した「42GB の DB に対する `quick_check` は 1200 秒 timeout で打ち切られる」という事実と、この workflow の Integrity check が無制限で 25分14秒かけて完走している事実は整合していて、互いの裏付けになっている。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operational documentation with the current database size estimate.
  * Increased the reseeding process time limit to better accommodate longer-running operations.
  * Clarified disk cleanup guidance to reflect approximately 42 GB of database storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->