### PR TITLE
requirements: aiohttp 3.14.1 -> 3.14.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.12
 uvicorn==0.34.2
 aiosqlite==0.21.0
-aiohttp==3.14.1
+aiohttp==3.14.3
 jinja2==3.1.6
 matplotlib==3.10.1
 asyncssh==2.20.0


### PR DESCRIPTION
default branch に出ていた Dependabot alert 3 件を消す。3 件とも同じパッケージ（`requirements.txt` の aiohttp）だった。

| GHSA | severity | 内容 | 影響範囲 |
|---|---|---|---|
| GHSA-cq5v-8q36-5273 | high | C HTTP response parser のエラー経路で heap 領域外読み取り（malformed chunked response） | <= 3.14.2 |
| GHSA-mfx4-hv73-q22v | medium | WebSocket upgrade 経由の HTTP request smuggling | <= 3.14.1 |
| GHSA-mq44-7p77-q5h7 | medium | WebSocket client が permessage-deflate 未ネゴシエートのまま圧縮フレームを受理 | <= 3.14.1 |

3.14.3 は high の first patched version で、残り 2 件もカバーする。PyPI の現行リリース（2026-07-23 公開、requires-python >=3.10 なので 3.12 runner に影響なし）であることを確認済み。

補足: scheduled pipeline 自体は脆弱なビルドに固定されていなかった。全 workflow が `pip install aiohttp` と**バージョン無指定**でインストールしているので、runner は最新を解決していた。今回の変更は `requirements.txt` から入れる経路の穴を塞ぐもの。