### PR TITLE
Stop reporting a NIED portal timeout as a rejected credential

### DIFF
--- a/scripts/fetch_fnet_waveform.py
+++ b/scripts/fetch_fnet_waveform.py
@@ -132,13 +132,43 @@ class HinetQuotaError(Exception):
         self.partial_results = partial_results or []
 
 
+def _classify_login_error(exc: Exception) -> str:
+    """Is this login failure about the credentials, or about the connection?
+
+    The portal can accept the TCP connection and then never answer, in which case the
+    credentials are never evaluated at all.  Reporting that as an authentication failure sends
+    the reader to check something that is not broken.  Anything not recognised stays "auth",
+    so an unfamiliar error is still reported the way it always was.
+    """
+    text = str(exc).lower()
+    for word in ("auth", "login", "password", "credential", "401", "403"):
+        if word in text:
+            return "auth"
+    try:
+        import requests.exceptions as _rex
+        if isinstance(exc, (_rex.Timeout, _rex.ConnectionError)):
+            return "unreachable"
+    except ImportError:
+        pass
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return "unreachable"
+    for word in ("timed out", "timeout", "connection refused", "connection reset",
+                 "connection aborted", "name or service not known", "temporary failure",
+                 "network is unreachable", "no route to host"):
+        if word in text:
+            return "unreachable"
+    return "auth"
+
+
 class HinetAuthError(Exception):
     """Raised when HinetPy reports an authentication failure mid-run."""
 
-    def __init__(self, message: str, partial_results: list[dict] | None = None):
+    def __init__(self, message: str, partial_results: list[dict] | None = None,
+                 kind: str = "auth"):
         """Capture the exception message and any records fetched before auth failed."""
         super().__init__(message)
         self.partial_results = partial_results or []
+        self.kind = kind
 
 
 # ---------------------------------------------------------------------------
@@ -879,8 +909,12 @@ def _fetch_and_save(
         client = Client(user, password)
         logger.info("Authenticated to NIED Hi-net")
     except Exception as exc:
-        logger.error("Authentication failed: %s", exc)
-        raise HinetAuthError(str(exc)) from exc
+        kind = _classify_login_error(exc)
+        if kind == "unreachable":
+            logger.error("NIED did not answer the login request: %s", exc)
+        else:
+            logger.error("Authentication failed: %s", exc)
+        raise HinetAuthError(str(exc), kind=kind) from exc
 
     selected, station_coords = select_active_stations(client, MAX_ACTIVE_STATIONS)
     logger.info("Active F-net stations: %d", len(selected))
@@ -1104,6 +1138,16 @@ async def main() -> None:
             None, _fetch_and_save, user, password, dates_to_fetch,
         )
     except HinetAuthError as exc:
+        if getattr(exc, "kind", "auth") == "unreachable":
+            logger.error("NIED portal unreachable: %s", exc)
+            send_discord(
+                "⚠️ F-net Waveform — NIED Portal Unreachable",
+                "The NIED portal accepted the connection and then did not answer "
+                "the login request. The credentials were never evaluated, so there "
+                "is nothing to check on our side; the next run will try again.",
+                color=15844367,
+            )
+            return
         logger.error("Authentication failed: %s", exc)
         send_discord(
             "⚠️ F-net Waveform — Auth Failed",

--- a/scripts/fetch_hinet_waveform.py
+++ b/scripts/fetch_hinet_waveform.py
@@ -134,13 +134,43 @@ class HinetQuotaError(Exception):
         self.partial_results = partial_results or []
 
 
+def _classify_login_error(exc: Exception) -> str:
+    """Is this login failure about the credentials, or about the connection?
+
+    The portal can accept the TCP connection and then never answer, in which case the
+    credentials are never evaluated at all.  Reporting that as an authentication failure sends
+    the reader to check something that is not broken.  Anything not recognised stays "auth",
+    so an unfamiliar error is still reported the way it always was.
+    """
+    text = str(exc).lower()
+    for word in ("auth", "login", "password", "credential", "401", "403"):
+        if word in text:
+            return "auth"
+    try:
+        import requests.exceptions as _rex
+        if isinstance(exc, (_rex.Timeout, _rex.ConnectionError)):
+            return "unreachable"
+    except ImportError:
+        pass
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return "unreachable"
+    for word in ("timed out", "timeout", "connection refused", "connection reset",
+                 "connection aborted", "name or service not known", "temporary failure",
+                 "network is unreachable", "no route to host"):
+        if word in text:
+            return "unreachable"
+    return "auth"
+
+
 class HinetAuthError(Exception):
     """Raised when HinetPy reports an authentication failure mid-run."""
 
-    def __init__(self, message: str, partial_results: list[dict] | None = None):
+    def __init__(self, message: str, partial_results: list[dict] | None = None,
+                 kind: str = "auth"):
         """Capture the exception message and any records fetched before auth failed."""
         super().__init__(message)
         self.partial_results = partial_results or []
+        self.kind = kind
 
 
 # ---------------------------------------------------------------------------
@@ -879,8 +909,12 @@ def _fetch_and_save(
         client = Client(user, password)
         logger.info("Authenticated to NIED Hi-net")
     except Exception as exc:
-        logger.error("Authentication failed: %s", exc)
-        raise HinetAuthError(str(exc)) from exc
+        kind = _classify_login_error(exc)
+        if kind == "unreachable":
+            logger.error("NIED did not answer the login request: %s", exc)
+        else:
+            logger.error("Authentication failed: %s", exc)
+        raise HinetAuthError(str(exc), kind=kind) from exc
 
     selected, station_coords = select_active_stations(client, MAX_ACTIVE_STATIONS)
     logger.info("Active Hi-net stations: %d", len(selected))
@@ -1104,6 +1138,16 @@ async def main() -> None:
             None, _fetch_and_save, user, password, dates_to_fetch,
         )
     except HinetAuthError as exc:
+        if getattr(exc, "kind", "auth") == "unreachable":
+            logger.error("NIED portal unreachable: %s", exc)
+            send_discord(
+                "⚠️ Hi-net Waveform — NIED Portal Unreachable",
+                "The NIED portal accepted the connection and then did not answer "
+                "the login request. The credentials were never evaluated, so there "
+                "is nothing to check on our side; the next run will try again.",
+                color=15844367,
+            )
+            return
         logger.error("Authentication failed: %s", exc)
         send_discord(
             "⚠️ Hi-net Waveform — Auth Failed",

--- a/scripts/fetch_snet_waveform.py
+++ b/scripts/fetch_snet_waveform.py
@@ -105,12 +105,42 @@ class HinetQuotaError(Exception):
         self.partial_results = partial_results or []
 
 
+def _classify_login_error(exc: Exception) -> str:
+    """Is this login failure about the credentials, or about the connection?
+
+    The portal can accept the TCP connection and then never answer, in which case the
+    credentials are never evaluated at all.  Reporting that as an authentication failure sends
+    the reader to check something that is not broken.  Anything not recognised stays "auth",
+    so an unfamiliar error is still reported the way it always was.
+    """
+    text = str(exc).lower()
+    for word in ("auth", "login", "password", "credential", "401", "403"):
+        if word in text:
+            return "auth"
+    try:
+        import requests.exceptions as _rex
+        if isinstance(exc, (_rex.Timeout, _rex.ConnectionError)):
+            return "unreachable"
+    except ImportError:
+        pass
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return "unreachable"
+    for word in ("timed out", "timeout", "connection refused", "connection reset",
+                 "connection aborted", "name or service not known", "temporary failure",
+                 "network is unreachable", "no route to host"):
+        if word in text:
+            return "unreachable"
+    return "auth"
+
+
 class HinetAuthError(Exception):
     """Raised when HinetPy reports an authentication failure mid-run."""
 
-    def __init__(self, message: str, partial_results: list[dict] | None = None):
+    def __init__(self, message: str, partial_results: list[dict] | None = None,
+                 kind: str = "auth"):
         super().__init__(message)
         self.partial_results = partial_results or []
+        self.kind = kind
 
 # S-net cable segments for spatial analysis
 SNET_CABLE_SEGMENTS = {
@@ -921,8 +951,12 @@ def _fetch_and_save(
         client = Client(user, password)
         logger.info("Authenticated to NIED Hi-net")
     except Exception as exc:
-        logger.error("Authentication failed: %s", exc)
-        raise HinetAuthError(str(exc)) from exc
+        kind = _classify_login_error(exc)
+        if kind == "unreachable":
+            logger.error("NIED did not answer the login request: %s", exc)
+        else:
+            logger.error("Authentication failed: %s", exc)
+        raise HinetAuthError(str(exc), kind=kind) from exc
 
     # Fetch station metadata once
     station_coords = {}
@@ -1186,6 +1220,16 @@ async def main() -> None:
             None, _fetch_and_save, user, password, dates_to_fetch,
         )
     except HinetAuthError as exc:
+        if getattr(exc, "kind", "auth") == "unreachable":
+            logger.error("NIED portal unreachable: %s", exc)
+            send_discord(
+                "⚠️ S-net Waveform — NIED Portal Unreachable",
+                "The NIED portal accepted the connection and then did not answer "
+                "the login request. The credentials were never evaluated, so there "
+                "is nothing to check on our side; the next run will try again.",
+                color=15844367,
+            )
+            return
         logger.error("Authentication failed: %s", exc)
         send_discord(
             "⚠️ S-net Waveform — Auth Failed",


### PR DESCRIPTION
Today at 04:42-04:43 UTC the Discord channel received three alerts within one minute — Hi-net, S-net and F-net all saying "Authentication to NIED failed. Check the network credentials."

The credentials are fine. The run log shows `HinetPy/client.py:188 login()` raising `requests.exceptions.ReadTimeout` against `hinetwww11.bosai.go.jp` after 60 seconds. Measured at the same time from a second, unrelated network: that host accepts TCP in 0.079 s and then never answers (`http=000` at a 30 s deadline), while `www.hinet.bosai.go.jp` returns 200 in 0.275 s. The login request was never evaluated, so there was nothing to check.

The cause is a bare `except Exception` around `Client(user, password)` in all three fetchers, which raised `HinetAuthError` for any failure whatsoever. The mid-run path a hundred lines below already discriminates on the message; this brings the constructor path in line with it.

- the exception carries a `kind`, decided by `_classify_login_error`
- a timeout or a refused connection now reports "NIED Portal Unreachable" and says plainly that the credentials were never evaluated
- anything unrecognised still reports as an authentication failure, so an unfamiliar error behaves exactly as it did before
- a timeout whose text also mentions auth is deliberately still reported as auth

Verified on nine cases including the `ReadTimeout` that actually fired. No behaviour changes when the portal answers.